### PR TITLE
Protect against monotonic time being non-monotonic

### DIFF
--- a/utp_utils.cpp
+++ b/utp_utils.cpp
@@ -54,7 +54,7 @@ void Time_Initialize()
 
 int64 abs64(int64 x) { return x < 0 ? -x : x; }
 
-uint64 UTP_GetMicroseconds()
+static uint64 GetMicroseconds()
 {
 	static bool time_init = false;
 	if (!time_init) {
@@ -94,7 +94,7 @@ uint64 UTP_GetMicroseconds()
 #if defined(__APPLE__)
 #include <mach/mach_time.h>
 
-uint64 UTP_GetMicroseconds()
+static uint64 GetMicroseconds()
 {
 	// http://developer.apple.com/mac/library/qa/qa2004/qa1398.html
 	// http://www.macresearch.org/tutorial_performance_and_time
@@ -118,7 +118,7 @@ uint64 UTP_GetMicroseconds()
    POSIX clocks work -- we could be running a recent libc with an ancient
    kernel (think OpenWRT). -- jch */
 
-uint64 UTP_GetMicroseconds()
+static uint64_t GetMicroseconds()
 {
 	static int have_posix_clocks = -1;
 	int rc;
@@ -154,6 +154,20 @@ uint64 UTP_GetMicroseconds()
 	}
 }
 #endif
+
+uint64 UTP_GetMicroseconds()
+{
+	static uint64 offset = 0, previous = 0;
+
+	uint64 now = GetMicroseconds() + offset;
+	if (previous > now) {
+		/* Eek! */
+		offset += previous - now;
+		now = previous;
+	}
+	previous = now;
+	return now;
+}
 
 uint32 UTP_GetMilliseconds()
 {


### PR DESCRIPTION
Within utp.cpp, there's a bunch of assertions that will cause us
to crash if monotonic time isn't.  While we're in principle already
protecting in the cases where non-monotonicity is likely (see the
gettimeofday case for generic Unix, for example), this protects for
all versions.
