### PR TITLE
Fix compilation with Solaris Studio

### DIFF
--- a/templates.h
+++ b/templates.h
@@ -43,7 +43,11 @@ template <typename T> static inline T clamp(T v, T mi, T ma)
 	return v;
 }
 
+#if (defined(__SVR4) && defined(__sun))
+#pragma pack(1)
+#else
 #pragma pack(push,1)
+#endif
 
 namespace aux
 {
@@ -68,7 +72,11 @@ typedef big_endian<int32> int32_big;
 typedef big_endian<uint32> uint32_big;
 typedef big_endian<uint16> uint16_big;
 
+#if (defined(__SVR4) && defined(__sun))
+#pragma pack(0)
+#else
 #pragma pack(pop)
+#endif
 
 template<typename T> static inline void zeromem(T *a, size_t count = 1) { memset(a, 0, count * sizeof(T)); }
 

--- a/utp.cpp
+++ b/utp.cpp
@@ -92,7 +92,11 @@ char addrbuf[65];
 char addrbuf2[65];
 #define addrfmt(x, s) x.fmt(s, sizeof(s))
 
+#if (defined(__SVR4) && defined(__sun))
+#pragma pack(1)
+#else
 #pragma pack(push,1)
+#endif
 
 struct PACKED_ATTRIBUTE PackedSockAddr {
 
@@ -280,7 +284,11 @@ struct PACKED_ATTRIBUTE PacketFormatExtensionsV1 {
 	byte extensions[8];
 };
 
+#if (defined(__SVR4) && defined(__sun))
+#pragma pack(0)
+#else
 #pragma pack(pop)
+#endif
 
 enum {
 	ST_DATA = 0,		// Data packet.


### PR DESCRIPTION
Use working syntax for #pragma pack() on Solaris.
