### PR TITLE
Fix pyutp installation failure on linux

### DIFF
--- a/pyutp/setup.py
+++ b/pyutp/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-from setuptools import setup, Library
+from setuptools import setup, Extension
 
 from utp import VERSION
 
@@ -24,7 +24,7 @@ else:
 # http://bugs.python.org/issue9023
 sources = [os.path.abspath(x) for x in sources]
 
-ext = Library(name="utp",
+ext = Extension(name="libutp",
               sources=sources,
               include_dirs=include_dirs,
               libraries=libraries,


### PR DESCRIPTION
pyutp/setup.py defines a Library rather than an Extension, which means that
on linux libutp.so isn't created (libutp.a is), which breaks pyutp.

Steps to reproduce:
1) run ubuntu 12.04
2) clone libutp
3) run setup.py build && setup.py install

The pyutp .egg package will contain libutp.a instead of the required libutp.so file the ctypes library is attempting to load.

This commit fixes that issue and has been tested on linux and mac OSX.

Thanks!
