### PR TITLE
Include more headers for FreeBSD compability (Issue #35)

### DIFF
--- a/utp.h
+++ b/utp.h
@@ -12,7 +12,9 @@
 #pragma comment(lib,"ws2_32.lib")
 #else
 #include <stdlib.h>
+#include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #endif
 


### PR DESCRIPTION
This commit will add sys/types.h and netinet/in.h for compability with FreeBSD systems. The patch has been confirmed to not cause problems for Linux systems which is why there are no unnecessary #ifdef's around them.

This is coming from (in this order):

http://github.com/bittorrent/libutp/issues/35
http://trac.transmissionbt.com/ticket/4915
http://bugs.gentoo.org/400929
