### PR TITLE
Allow appending CXXFLAGS from command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SRCS = utp.cpp utp_utils.cpp
 OBJS = utp.o utp_utils.o
-CXXFLAGS = -fno-exceptions -fno-rtti -Wall -g
+override CXXFLAGS := -fno-exceptions -fno-rtti -Wall -g $(CXXFLAGS)
 
 all: libutp.a
 


### PR DESCRIPTION
This allows appending CXXFLAGS from the command line when building libutp.

`$ make` before patch:

```
g++ -c -DPOSIX -I . -I utp_config_lib -fno-exceptions -fno-rtti -Wall -g  utp.cpp
g++ -c -DPOSIX -I . -I utp_config_lib -fno-exceptions -fno-rtti -Wall -g  utp_utils.cpp
rm -f libutp.a
ar q libutp.a utp.o utp_utils.o
ar: creating libutp.a
ranlib libutp.a
```

`$ make` after patch:

```
g++ -c -DPOSIX -I . -I utp_config_lib -fno-exceptions -fno-rtti -Wall -g  utp.cpp
g++ -c -DPOSIX -I . -I utp_config_lib -fno-exceptions -fno-rtti -Wall -g  utp_utils.cpp
rm -f libutp.a
ar q libutp.a utp.o utp_utils.o
ar: creating libutp.a
ranlib libutp.a
```

`make CXXFLAGS=-fPIC` before patch:

```
g++ -c -DPOSIX -I . -I utp_config_lib -fPIC utp.cpp
g++ -c -DPOSIX -I . -I utp_config_lib -fPIC utp_utils.cpp
rm -f libutp.a
ar q libutp.a utp.o utp_utils.o
ar: creating libutp.a
ranlib libutp.a
```

`make CXXFLAGS=-fPIC` after patch:

```
g++ -c -DPOSIX -I . -I utp_config_lib -fno-exceptions -fno-rtti -Wall -g -fPIC utp.cpp
g++ -c -DPOSIX -I . -I utp_config_lib -fno-exceptions -fno-rtti -Wall -g -fPIC utp_utils.cpp
rm -f libutp.a
ar q libutp.a utp.o utp_utils.o
ar: creating libutp.a
ranlib libutp.a
```
