### PR TITLE
optimize flush packets

### DIFF
--- a/utp_templates.h
+++ b/utp_templates.h
@@ -134,6 +134,13 @@ public:
 		return r;
 	}
 
+	void RemoveElement(size_t index) {
+		if (index < count-1) {
+			memmove(&mem[index], &mem[index+1], (count - index - 1) * sizeof(T));
+		}
+		Resize(count-1);
+	}
+
 	T inline &Append() {
 		if (count >= alloc) Grow();
 		return mem[count++];


### PR DESCRIPTION
This optimizes flush_packets(). Instead of looping over all packets in the send buffer, just loop over the ones we know needs sending. This patch almost doubles the send rate on a raspberry pi (you get a lot of cache misses with the previous code).

This particular patch hasn't been well tested, it was pulled out of a larger patch set which was though.
