### PR TITLE
defer writable

### DIFF
--- a/utp_internal.h
+++ b/utp_internal.h
@@ -119,6 +119,7 @@ struct struct_utp_context {
 	utp_context_stats context_stats;
 	UTPSocket *last_utp_socket;
 	Array<UTPSocket*> ack_sockets;
+	Array<UTPSocket*> writable_sockets;
 	Array<RST_Info> rst_info;
 	UTPSocketHT *utp_sockets;
 	size_t target_delay;


### PR DESCRIPTION
defer notifying the upper layer of the socket becoming writable until th...e underlying UDP socket is drained. saves CPU but batching work better.

Given that the upper layer in uTorrent does quite a lot of work every time it's notified of the socket being writable, this can save significant CPU usage.
