### PR TITLE
fast socket start

### DIFF
--- a/utp_internal.h
+++ b/utp_internal.h
@@ -65,6 +65,28 @@ struct PACKED_ATTRIBUTE RST_Info {
 	uint64 timestamp;
 };
 
+struct UTPPathData {
+	PackedSockAddr key;
+
+	// information about the path
+	int cwnd;
+	int ssthres;
+	int mtu_floor;
+	int mtu_ceiling;
+	int timestamp; // milliseconds
+
+	utp_link_t link;
+};
+
+struct UTPPathHistory : utpHashTable<PackedSockAddr, UTPPathData> {
+	UTPPathHistory() {
+		this->Create(257, 15);
+	}
+	~UTPPathHistory() {
+		this->Free();
+	}
+};
+
 // It's really important that we don't have duplicate keys in the hash table.
 // If we do, we'll eventually crash. if we try to remove the second instance
 // of the key, we'll accidentally remove the first instead. then later,
@@ -121,6 +143,7 @@ struct struct_utp_context {
 	Array<UTPSocket*> ack_sockets;
 	Array<RST_Info> rst_info;
 	UTPSocketHT *utp_sockets;
+	UTPPathHistory utp_paths;
 	size_t target_delay;
 	size_t opt_sndbuf;
 	size_t opt_rcvbuf;

--- a/utp_packedsockaddr.h
+++ b/utp_packedsockaddr.h
@@ -49,7 +49,7 @@ struct PACKED_ATTRIBUTE PackedSockAddr {
 	void set(const SOCKADDR_STORAGE* sa, socklen_t len);
 
 	PackedSockAddr(const SOCKADDR_STORAGE* sa, socklen_t len);
-	PackedSockAddr(void);
+	PackedSockAddr();
 
 	SOCKADDR_STORAGE get_sockaddr_storage(socklen_t *len) const;
 	cstr fmt(str s, size_t len) const;


### PR DESCRIPTION
allow new sockets to be initialized with state from existing or recently existing connections to the same IP. This should give some performance improvements in the case of opening many sockets in sequence to the same IP, transferring in bulk.

what it does is to initialize the new socket with the same cwnd, mtu and ssthres as the existing (or recently existing) socket to the same IP. This way we may save the ramp-up of cwnd for the new socket.
