### PR TITLE
Update README.md to reference ucat.c as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ it may be used from a multi-threaded environment as well.
 
 See utp.h for more details and other API documentation.
 
-## Examples
+## Example
 
-See the utp_test and utp_file directories for examples.
+See ucat.c. Build with:
+ 
+   make ucat
 
 ## Building
 


### PR DESCRIPTION
The documentation references an examples directory that does not exist. Looking back into the repo history I found that most of the functionality was brought into ucat.

@jpcottin 