### PR TITLE
Allow overrides of PACKED_ATTRIBUTE preprocessor macro

### DIFF
--- a/utp_types.h
+++ b/utp_types.h
@@ -25,13 +25,13 @@
 
 // Allow libutp consumers or prerequisites to override PACKED_ATTRIBUTE
 #ifndef PACKED_ATTRIBUTE
-#ifdef __GNUC__
+#if defined BROKEN_GCC_STRUCTURE_PACKING && defined __GNUC__
 	// Used for gcc tool chains accepting but not supporting pragma pack
 	// See http://gcc.gnu.org/onlinedocs/gcc/Type-Attributes.html
 	#define PACKED_ATTRIBUTE __attribute__((__packed__))
 #else
 	#define PACKED_ATTRIBUTE
-#endif
+#endif // defined BROKEN_GCC_STRUCTURE_PACKING && defined __GNUC__
 #endif // ndef PACKED_ATTRIBUTE
 
 #ifdef __GNUC__

--- a/utp_types.h
+++ b/utp_types.h
@@ -23,6 +23,8 @@
 #ifndef __UTP_TYPES_H__
 #define __UTP_TYPES_H__
 
+// Allow libutp consumers or prerequisites to override PACKED_ATTRIBUTE
+#ifndef PACKED_ATTRIBUTE
 #ifdef __GNUC__
 	// Used for gcc tool chains accepting but not supporting pragma pack
 	// See http://gcc.gnu.org/onlinedocs/gcc/Type-Attributes.html
@@ -30,6 +32,7 @@
 #else
 	#define PACKED_ATTRIBUTE
 #endif
+#endif // ndef PACKED_ATTRIBUTE
 
 #ifdef __GNUC__
 	#define ALIGNED_ATTRIBUTE(x)  __attribute__((aligned (x)))


### PR DESCRIPTION
This prevents libutp code from defining PACKED_ATTRIBUTE if it has already been defined.  This greatly reduces noisy gcc warnings since to override definition - avoids gcc warnings about redefining a preprocessor macro when building client products since this macro is defined elsewhere in client code and has different conditions to its definition than this definition.

@xercesblue @angitbit please review.