### PR TITLE
Feature modify perf pr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 OBJS     = utp_internal.o utp_utils.o utp_hash.o utp_callbacks.o utp_api.o utp_packedsockaddr.o
-CFLAGS   = -Wall -DPOSIX -g -fno-exceptions -O2
+CFLAGS   = -Wall -DPOSIX -g -fno-exceptions $(OPT)
+OPT ?= -O3
 CXXFLAGS = $(CFLAGS) -fPIC -fno-rtti
 CC       = gcc
 CXX      = g++

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OBJS     = utp_internal.o utp_utils.o utp_hash.o utp_callbacks.o utp_api.o utp_packedsockaddr.o
-CFLAGS   = -Wall -DPOSIX -g -fno-exceptions
+CFLAGS   = -Wall -DPOSIX -g -fno-exceptions -O2
 CXXFLAGS = $(CFLAGS) -fPIC -fno-rtti
 CC       = gcc
 CXX      = g++
@@ -8,10 +8,10 @@ CXXFLAGS += -Wno-sign-compare
 CXXFLAGS += -fpermissive
 
 # Uncomment to enable utp_get_stats(), and a few extra sanity checks
-CFLAGS += -D_DEBUG
+#CFLAGS += -D_DEBUG
 
 # Uncomment to enable debug logging
-CFLAGS += -DUTP_DEBUG_LOGGING
+#CFLAGS += -DUTP_DEBUG_LOGGING
 
 # Dynamically determine if librt is available.  If so, assume we need to link
 # against it for clock_gettime(2).  This is required for clean builds on OSX;

--- a/ucat.c
+++ b/ucat.c
@@ -258,7 +258,7 @@ uint64 callback_sendto(utp_callback_arguments *a)
 {
 	struct sockaddr_in *sin = (struct sockaddr_in *) a->address;
 
-	debug("sendto: %zd byte packet to %s:%d%s\n", a->address_len, inet_ntoa(sin->sin_addr), ntohs(sin->sin_port),
+	debug("sendto: %zd byte packet to %s:%d%s\n", a->len, inet_ntoa(sin->sin_addr), ntohs(sin->sin_port),
 				(a->flags & UTP_UDP_DONTFRAG) ? "  (DF bit requested, but not yet implemented)" : "");
 
 	if (o_debug >= 3)

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -3423,11 +3423,9 @@ void struct_utp_context::log_unchecked(utp_socket *socket, char const *fmt, ...)
 
 inline bool struct_utp_context::would_log(int level)
 {
-	switch (level) {
-		case UTP_LOG_NORMAL: if (!log_normal) return false;
-		case UTP_LOG_MTU:    if (!log_mtu)    return false;
-		case UTP_LOG_DEBUG:  if (!log_debug)  return false;
-	}
+	if (level == UTP_LOG_NORMAL) return log_normal;
+	if (level == UTP_LOG_MTU) return log_mtu;
+	if (level == UTP_LOG_DEBUG) return log_debug;
     return true;
 }
 

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -3426,7 +3426,7 @@ inline bool struct_utp_context::would_log(int level)
 	if (level == UTP_LOG_NORMAL) return log_normal;
 	if (level == UTP_LOG_MTU) return log_mtu;
 	if (level == UTP_LOG_DEBUG) return log_debug;
-    return true;
+	return true;
 }
 
 utp_socket_stats* utp_get_stats(utp_socket *socket)

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -553,6 +553,11 @@ struct UTPSocket {
 		va_list va;
 		char buf[4096], buf2[4096];
 
+		// don't bother with vsnprintf() etc calls if we're not going to log.
+		if (!ctx->would_log(level)) {
+			return;
+		}
+
 		va_start(va, fmt);
 		vsnprintf(buf, 4096, fmt, va);
 		va_end(va);
@@ -561,7 +566,7 @@ struct UTPSocket {
 		snprintf(buf2, 4096, "%p %s %06u %s", this, addrfmt(addr, addrbuf), conn_id_recv, buf);
 		buf2[4095] = '\0';
 
-		ctx->log(level, this, buf2);
+		ctx->log_unchecked(this, buf2);
 	}
 
 	void schedule_ack();
@@ -3382,12 +3387,18 @@ void* utp_get_userdata(utp_socket *socket) {
 
 void struct_utp_context::log(int level, utp_socket *socket, char const *fmt, ...)
 {
-	switch (level) {
-		case UTP_LOG_NORMAL:	if (!log_normal) return;
-		case UTP_LOG_MTU:		if (!log_mtu)    return;
-		case UTP_LOG_DEBUG:		if (!log_debug)  return;
+	if (!would_log(level)) {
+		return;
 	}
 
+	va_list va;
+	va_start(va, fmt);
+	log_unchecked(socket, fmt, va);
+	va_end(va);
+}
+
+void struct_utp_context::log_unchecked(utp_socket *socket, char const *fmt, ...)
+{
 	va_list va;
 	char buf[4096];
 
@@ -3397,6 +3408,16 @@ void struct_utp_context::log(int level, utp_socket *socket, char const *fmt, ...
 	va_end(va);
 
 	utp_call_log(this, socket, (const byte *)buf);
+}
+
+inline bool struct_utp_context::would_log(int level)
+{
+	switch (level) {
+		case UTP_LOG_NORMAL: if (!log_normal) return false;
+		case UTP_LOG_MTU:    if (!log_mtu)    return false;
+		case UTP_LOG_DEBUG:  if (!log_debug)  return false;
+	}
+    return true;
 }
 
 utp_socket_stats* utp_get_stats(utp_socket *socket)

--- a/utp_internal.h
+++ b/utp_internal.h
@@ -130,6 +130,8 @@ struct struct_utp_context {
 	~struct_utp_context();
 
 	void log(int level, utp_socket *socket, char const *fmt, ...);
+	void log_unchecked(utp_socket *socket, char const *fmt, ...);
+	bool would_log(int level);
 
 	bool log_normal:1;	// log normal events?
 	bool log_mtu:1;		// log MTU related events?


### PR DESCRIPTION
@B-C  @xercesblue 
This is a slight modification of PR #84 
As explained in #84 the goals were to prevent the usage of vsnprintf() if log is not necessary. There was also a bug in one of the debug statement 
