### PR TITLE
Add runtime path to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ libutp.a: $(OBJS)
 	ar rvs libutp.a $(OBJS)
 
 ucat: ucat.o libutp.so
-	$(CC) $(CFLAGS) -o ucat ucat.o -L. -lutp $(LDFLAGS)
+	$(CC) $(CFLAGS) -o ucat ucat.o -L. -lutp -Wl,-rpath=. $(LDFLAGS)
 
 ucat-static: ucat.o libutp.a
 	$(CXX) $(CXXFLAGS) -o ucat-static ucat.o libutp.a $(LDFLAGS)


### PR DESCRIPTION
The current Makefile can't link to "libutp.so" without specifying the runtime path. This is a pull request to  easily fix it.