### PR TITLE
ON_READ callback may drop packets

### DIFF
--- a/utp_callbacks.cpp
+++ b/utp_callbacks.cpp
@@ -69,16 +69,16 @@ void utp_call_on_error(utp_context *ctx, utp_socket *socket, int error_code)
 	ctx->callbacks[UTP_ON_ERROR](&args);
 }
 
-void utp_call_on_read(utp_context *ctx, utp_socket *socket, const byte *buf, size_t len)
+bool utp_call_on_read(utp_context *ctx, utp_socket *socket, const byte *buf, size_t len)
 {
 	utp_callback_arguments args;
-	if (!ctx->callbacks[UTP_ON_READ]) return;
+	if (!ctx->callbacks[UTP_ON_READ]) return false;
 	args.callback_type = UTP_ON_READ;
 	args.context = ctx;
 	args.socket = socket;
 	args.buf = buf;
 	args.len = len;
-	ctx->callbacks[UTP_ON_READ](&args);
+	return ctx->callbacks[UTP_ON_READ](&args) == 0;
 }
 
 void utp_call_on_overhead_statistics(utp_context *ctx, utp_socket *socket, int send, size_t len, int type)

--- a/utp_callbacks.h
+++ b/utp_callbacks.h
@@ -31,7 +31,7 @@ int utp_call_on_firewall(utp_context *ctx, const struct sockaddr *address, sockl
 void utp_call_on_accept(utp_context *ctx, utp_socket *s, const struct sockaddr *address, socklen_t address_len);
 void utp_call_on_connect(utp_context *ctx, utp_socket *s);
 void utp_call_on_error(utp_context *ctx, utp_socket *s, int error_code);
-void utp_call_on_read(utp_context *ctx, utp_socket *s, const byte *buf, size_t len);
+bool utp_call_on_read(utp_context *ctx, utp_socket *s, const byte *buf, size_t len);
 void utp_call_on_overhead_statistics(utp_context *ctx, utp_socket *s, int send, size_t len, int type);
 void utp_call_on_delay_sample(utp_context *ctx, utp_socket *s, int sample_ms);
 void utp_call_on_state_change(utp_context *ctx, utp_socket *s, int state);


### PR DESCRIPTION
If the ON_READ callback returns a value different than 0, then the packet will be droped.
This way the client may control the flow by dropping packet it is not ready yet to process.