### PR TITLE
Remove duplicate word "provides" from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Copyright (c) 2010 BitTorrent, Inc.
 
 uTP is a TCP-like implementation of [LEDBAT][ledbat] documented as a BitTorrent
-extension in [BEP-29][bep29]. uTP provides provides reliable, ordered delivery
-while maintaining minimum extra delay. It is implemented on top of UDP to be
+extension in [BEP-29][bep29]. uTP provides reliable, ordered delivery while
+maintaining minimum extra delay. It is implemented on top of UDP to be
 cross-platform and functional today. As a result, uTP is the primary transport
 for uTorrent peer-to-peer connections.
 


### PR DESCRIPTION
It used to say `uTP provides provides`.

I also moved "while" to keep line-length somewhat consistent.