### PR TITLE
Only stay a finite time in the CS_SYN_RECV state

### DIFF
--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -2987,6 +2987,7 @@ int utp_process_udp(utp_context *ctx, const byte *buffer, size_t len, const stru
 		conn->seq_nr = utp_call_get_random(ctx, NULL);
 		conn->fast_resend_seq_nr = conn->seq_nr;
 		conn->state = CS_SYN_RECV;
+		conn->rto_timeout = utp_call_get_milliseconds(conn->ctx, conn) + conn->rto;
 
 		const size_t read = utp_process_incoming(conn, buffer, len, true);
 


### PR DESCRIPTION
When an accepting socket receives a ST_SYN packet, it switches itself to CS_SYN_RECV state where it remains until it either receives a data packet or the socket is destroyed (possibly indefinitely).

I am not sure whether the user of libutp is expected to set up a timer to explicitly close such socket (if no data arrive), but given that it's not documented it seems that a default timeout would be appropriate.