### PR TITLE
Set `got_fin` if in CS_SYN_RECV state and receive ST_FIN

### DIFF
--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -2315,7 +2315,8 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 
 	// The connection is not in a state that can accept data?
 	if (conn->state != CS_CONNECTED &&
-		conn->state != CS_CONNECTED_FULL) {
+		conn->state != CS_CONNECTED_FULL &&
+		conn->state != CS_SYN_RECV) {
 		return 0;
 	}
 


### PR DESCRIPTION
Currently the server socket ignores the ST_FIN packet when in CS_SYN_RECV state. So when the other end closes the connection, the socket in CS_SYN_RECV state has no other option than to timeout.

This commit causes the serving socket not to ignore the ST_FIN packet in that state so that it can exit early.