### PR TITLE
Cast to void

### DIFF
--- a/utp_internal.h
+++ b/utp_internal.h
@@ -76,7 +76,7 @@ struct UTPSocketKey {
 	uint32 recv_id;		 // "conn_seed", "conn_id"
 
 	UTPSocketKey(const PackedSockAddr& _addr, uint32 _recv_id) {
-		memset(this, 0, sizeof(*this));
+		memset(static_cast<void*>(this), 0, sizeof(*this));
 		addr = _addr;
 		recv_id = _recv_id;
 	}


### PR DESCRIPTION
Prevent warnings from popping up in GCC >= 8.1

```bash
In file included from utp_api.cpp:26:
utp_internal.h: In constructor ‘UTPSocketKey::UTPSocketKey(const PackedSockAddr&, uint32)’:
utp_internal.h:79:32: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct UTPSocketKey’; use assignment instead [-Wclass-memaccess]
   79 |   memset(this, 0, sizeof(*this));
      |                                ^
utp_internal.h:74:8: note: ‘struct UTPSocketKey’ declared here
   74 | struct UTPSocketKey {
      |        ^~~~~~~~~~~~
```

Resolved like in this issue: https://github.com/intel/tbb/issues/54