### PR TITLE
Use standard/built-in types instead of local typedefs where possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 OBJS     = utp_internal.o utp_utils.o utp_hash.o utp_callbacks.o utp_api.o utp_packedsockaddr.o
-CFLAGS   = -Wall -DPOSIX -g -fno-exceptions $(OPT)
+CMNFLAGS = -Wall -DPOSIX -D_POSIX_C_SOURCE=200112L -g -fno-exceptions $(OPT)
+CFLAGS   = $(CMNFLAGS)
 OPT ?= -O3
-CXXFLAGS = $(CFLAGS) -fPIC -fno-rtti
+CXXFLAGS = $(CMNFLAGS) -fPIC -fno-rtti
 CC       = gcc
 CXX      = g++
 
 CXXFLAGS += -Wno-sign-compare
 CXXFLAGS += -fpermissive
+
+CFLAGS   += -std=c99
+CXXFLAGS += -std=c++98
 
 # Uncomment to enable utp_get_stats(), and a few extra sanity checks
 #CFLAGS += -D_DEBUG

--- a/ucat.c
+++ b/ucat.c
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -241,14 +242,14 @@ uint64_t callback_on_state_change(utp_callback_arguments *a)
 			stats = utp_get_stats(a->socket);
 			if (stats) {
 				debug("Socket Statistics:\n");
-				debug("    Bytes sent:          %d\n", stats->nbytes_xmit);
-				debug("    Bytes received:      %d\n", stats->nbytes_recv);
-				debug("    Packets received:    %d\n", stats->nrecv);
-				debug("    Packets sent:        %d\n", stats->nxmit);
-				debug("    Duplicate receives:  %d\n", stats->nduprecv);
-				debug("    Retransmits:         %d\n", stats->rexmit);
-				debug("    Fast Retransmits:    %d\n", stats->fastrexmit);
-				debug("    Best guess at MTU:   %d\n", stats->mtu_guess);
+				debug("    Bytes sent:          %" PRIu64 "\n", stats->nbytes_xmit);
+				debug("    Bytes received:      %" PRIu64 "\n", stats->nbytes_recv);
+				debug("    Packets received:    %" PRIu32 "\n", stats->nrecv);
+				debug("    Packets sent:        %" PRIu32 "\n", stats->nxmit);
+				debug("    Duplicate receives:  %" PRIu32 "\n", stats->nduprecv);
+				debug("    Retransmits:         %" PRIu32 "\n", stats->rexmit);
+				debug("    Fast Retransmits:    %" PRIu32 "\n", stats->fastrexmit);
+				debug("    Best guess at MTU:   %" PRIu32 "\n", stats->mtu_guess);
 			}
 			else {
 				debug("No socket statistics available\n");
@@ -621,9 +622,9 @@ int main(int argc, char *argv[])
 
 	if (stats) {
 		debug("           Bucket size:    <23    <373    <723    <1400    >1400\n");
-		debug("Number of packets sent:  %5d   %5d   %5d    %5d    %5d\n",
+		debug("Number of packets sent:  %5" PRIu32 "   %5" PRIu32 "   %5" PRIu32 "    %5" PRIu32 "    %5" PRIu32 "\n",
 			stats->_nraw_send[0], stats->_nraw_send[1], stats->_nraw_send[2], stats->_nraw_send[3], stats->_nraw_send[4]);
-		debug("Number of packets recv:  %5d   %5d   %5d    %5d    %5d\n",
+		debug("Number of packets recv:  %5" PRIu32 "   %5" PRIu32 "   %5" PRIu32 "    %5" PRIu32 "    %5" PRIu32 "\n",
 			stats->_nraw_recv[0], stats->_nraw_recv[1], stats->_nraw_recv[2], stats->_nraw_recv[3], stats->_nraw_recv[4]);
 	}
 	else {

--- a/ucat.c
+++ b/ucat.c
@@ -163,7 +163,7 @@ out:
 	}
 }
 
-uint64 callback_on_read(utp_callback_arguments *a)
+uint64_t callback_on_read(utp_callback_arguments *a)
 {
 	const unsigned char *p;
 	ssize_t len, left;
@@ -181,7 +181,7 @@ uint64 callback_on_read(utp_callback_arguments *a)
 	return 0;
 }
 
-uint64 callback_on_firewall(utp_callback_arguments *a)
+uint64_t callback_on_firewall(utp_callback_arguments *a)
 {
 	if (! o_listen) {
 		debug("Firewalling unexpected inbound connection in non-listen mode\n");
@@ -197,7 +197,7 @@ uint64 callback_on_firewall(utp_callback_arguments *a)
 	return 0;
 }
 
-uint64 callback_on_accept(utp_callback_arguments *a)
+uint64_t callback_on_accept(utp_callback_arguments *a)
 {
 	assert(!s);
 	s = a->socket;
@@ -206,7 +206,7 @@ uint64 callback_on_accept(utp_callback_arguments *a)
 	return 0;
 }
 
-uint64 callback_on_error(utp_callback_arguments *a)
+uint64_t callback_on_error(utp_callback_arguments *a)
 {
 	fprintf(stderr, "Error: %s\n", utp_error_code_names[a->error_code]);
 	utp_close(s);
@@ -216,7 +216,7 @@ uint64 callback_on_error(utp_callback_arguments *a)
 	return 0;
 }
 
-uint64 callback_on_state_change(utp_callback_arguments *a)
+uint64_t callback_on_state_change(utp_callback_arguments *a)
 {
 	debug("state %d: %s\n", a->state, utp_state_names[a->state]);
 	utp_socket_stats *stats;
@@ -262,7 +262,7 @@ uint64 callback_on_state_change(utp_callback_arguments *a)
 	return 0;
 }
 
-uint64 callback_sendto(utp_callback_arguments *a)
+uint64_t callback_sendto(utp_callback_arguments *a)
 {
 	struct sockaddr_in *sin = (struct sockaddr_in *) a->address;
 
@@ -276,7 +276,7 @@ uint64 callback_sendto(utp_callback_arguments *a)
 	return 0;
 }
 
-uint64 callback_log(utp_callback_arguments *a)
+uint64_t callback_log(utp_callback_arguments *a)
 {
 	fprintf(stderr, "log: %s\n", a->buf);
 	return 0;

--- a/utp.h
+++ b/utp.h
@@ -102,7 +102,7 @@ typedef struct {
 	size_t len;
 	uint32_t flags;
 	int callback_type;
-	const byte *buf;
+	const uint8_t *buf;
 
 	union {
 		const struct sockaddr *address;
@@ -154,9 +154,9 @@ void*			utp_context_set_userdata		(utp_context *ctx, void *userdata);
 void*			utp_context_get_userdata		(utp_context *ctx);
 int				utp_context_set_option			(utp_context *ctx, int opt, int val);
 int				utp_context_get_option			(utp_context *ctx, int opt);
-int				utp_process_udp					(utp_context *ctx, const byte *buf, size_t len, const struct sockaddr *to, socklen_t tolen);
-int				utp_process_icmp_error			(utp_context *ctx, const byte *buffer, size_t len, const struct sockaddr *to, socklen_t tolen);
-int				utp_process_icmp_fragmentation	(utp_context *ctx, const byte *buffer, size_t len, const struct sockaddr *to, socklen_t tolen, uint16_t next_hop_mtu);
+int				utp_process_udp					(utp_context *ctx, const uint8_t *buf, size_t len, const struct sockaddr *to, socklen_t tolen);
+int				utp_process_icmp_error			(utp_context *ctx, const uint8_t *buffer, size_t len, const struct sockaddr *to, socklen_t tolen);
+int				utp_process_icmp_fragmentation	(utp_context *ctx, const uint8_t *buffer, size_t len, const struct sockaddr *to, socklen_t tolen, uint16_t next_hop_mtu);
 void			utp_check_timeouts				(utp_context *ctx);
 void			utp_issue_deferred_acks			(utp_context *ctx);
 utp_context_stats* utp_get_context_stats		(utp_context *ctx);

--- a/utp.h
+++ b/utp.h
@@ -100,7 +100,7 @@ typedef struct {
 	utp_context *context;
 	utp_socket *socket;
 	size_t len;
-	uint32 flags;
+	uint32_t flags;
 	int callback_type;
 	const byte *buf;
 
@@ -118,24 +118,24 @@ typedef struct {
 	};
 } utp_callback_arguments;
 
-typedef uint64 utp_callback_t(utp_callback_arguments *);
+typedef uint64_t utp_callback_t(utp_callback_arguments *);
 
 // Returned by utp_get_context_stats()
 typedef struct {
-	uint32 _nraw_recv[5];	// total packets recieved less than 300/600/1200/MTU bytes fpr all connections (context-wide)
-	uint32 _nraw_send[5];	// total packets sent     less than 300/600/1200/MTU bytes for all connections (context-wide)
+	uint32_t _nraw_recv[5];	// total packets recieved less than 300/600/1200/MTU bytes fpr all connections (context-wide)
+	uint32_t _nraw_send[5];	// total packets sent     less than 300/600/1200/MTU bytes for all connections (context-wide)
 } utp_context_stats;
 
 // Returned by utp_get_stats()
 typedef struct {
-	uint64 nbytes_recv;	// total bytes received
-	uint64 nbytes_xmit;	// total bytes transmitted
-	uint32 rexmit;		// retransmit counter
-	uint32 fastrexmit;	// fast retransmit counter
-	uint32 nxmit;		// transmit counter
-	uint32 nrecv;		// receive counter (total)
-	uint32 nduprecv;	// duplicate receive counter
-	uint32 mtu_guess;	// Best guess at MTU
+	uint64_t nbytes_recv;	// total bytes received
+	uint64_t nbytes_xmit;	// total bytes transmitted
+	uint32_t rexmit;		// retransmit counter
+	uint32_t fastrexmit;	// fast retransmit counter
+	uint32_t nxmit;		// transmit counter
+	uint32_t nrecv;		// receive counter (total)
+	uint32_t nduprecv;	// duplicate receive counter
+	uint32_t mtu_guess;	// Best guess at MTU
 } utp_socket_stats;
 
 #define UTP_IOV_MAX 1024
@@ -156,7 +156,7 @@ int				utp_context_set_option			(utp_context *ctx, int opt, int val);
 int				utp_context_get_option			(utp_context *ctx, int opt);
 int				utp_process_udp					(utp_context *ctx, const byte *buf, size_t len, const struct sockaddr *to, socklen_t tolen);
 int				utp_process_icmp_error			(utp_context *ctx, const byte *buffer, size_t len, const struct sockaddr *to, socklen_t tolen);
-int				utp_process_icmp_fragmentation	(utp_context *ctx, const byte *buffer, size_t len, const struct sockaddr *to, socklen_t tolen, uint16 next_hop_mtu);
+int				utp_process_icmp_fragmentation	(utp_context *ctx, const byte *buffer, size_t len, const struct sockaddr *to, socklen_t tolen, uint16_t next_hop_mtu);
 void			utp_check_timeouts				(utp_context *ctx);
 void			utp_issue_deferred_acks			(utp_context *ctx);
 utp_context_stats* utp_get_context_stats		(utp_context *ctx);
@@ -170,7 +170,7 @@ ssize_t			utp_write						(utp_socket *s, void *buf, size_t count);
 ssize_t			utp_writev						(utp_socket *s, struct utp_iovec *iovec, size_t num_iovecs);
 int				utp_getpeername					(utp_socket *s, struct sockaddr *addr, socklen_t *addrlen);
 void			utp_read_drained				(utp_socket *s);
-int				utp_get_delays					(utp_socket *s, uint32 *ours, uint32 *theirs, uint32 *age);
+int				utp_get_delays					(utp_socket *s, uint32_t *ours, uint32_t *theirs, uint32_t *age);
 utp_socket_stats* utp_get_stats					(utp_socket *s);
 utp_context*	utp_get_context					(utp_socket *s);
 void			utp_shutdown					(utp_socket *s, int how);

--- a/utp_callbacks.cpp
+++ b/utp_callbacks.cpp
@@ -116,7 +116,7 @@ void utp_call_on_state_change(utp_context *ctx, utp_socket *socket, int state)
 	ctx->callbacks[UTP_ON_STATE_CHANGE](&args);
 }
 
-uint16 utp_call_get_udp_mtu(utp_context *ctx, utp_socket *socket, const struct sockaddr *address, socklen_t address_len)
+uint16_t utp_call_get_udp_mtu(utp_context *ctx, utp_socket *socket, const struct sockaddr *address, socklen_t address_len)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_GET_UDP_MTU]) return 0;
@@ -125,10 +125,10 @@ uint16 utp_call_get_udp_mtu(utp_context *ctx, utp_socket *socket, const struct s
 	args.socket = socket;
 	args.address = address;
 	args.address_len = address_len;
-	return (uint16)ctx->callbacks[UTP_GET_UDP_MTU](&args);
+	return (uint16_t)ctx->callbacks[UTP_GET_UDP_MTU](&args);
 }
 
-uint16 utp_call_get_udp_overhead(utp_context *ctx, utp_socket *socket, const struct sockaddr *address, socklen_t address_len)
+uint16_t utp_call_get_udp_overhead(utp_context *ctx, utp_socket *socket, const struct sockaddr *address, socklen_t address_len)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_GET_UDP_OVERHEAD]) return 0;
@@ -137,10 +137,10 @@ uint16 utp_call_get_udp_overhead(utp_context *ctx, utp_socket *socket, const str
 	args.socket = socket;
 	args.address = address;
 	args.address_len = address_len;
-	return (uint16)ctx->callbacks[UTP_GET_UDP_OVERHEAD](&args);
+	return (uint16_t)ctx->callbacks[UTP_GET_UDP_OVERHEAD](&args);
 }
 
-uint64 utp_call_get_milliseconds(utp_context *ctx, utp_socket *socket)
+uint64_t utp_call_get_milliseconds(utp_context *ctx, utp_socket *socket)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_GET_MILLISECONDS]) return 0;
@@ -150,7 +150,7 @@ uint64 utp_call_get_milliseconds(utp_context *ctx, utp_socket *socket)
 	return ctx->callbacks[UTP_GET_MILLISECONDS](&args);
 }
 
-uint64 utp_call_get_microseconds(utp_context *ctx, utp_socket *socket)
+uint64_t utp_call_get_microseconds(utp_context *ctx, utp_socket *socket)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_GET_MICROSECONDS]) return 0;
@@ -160,14 +160,14 @@ uint64 utp_call_get_microseconds(utp_context *ctx, utp_socket *socket)
 	return ctx->callbacks[UTP_GET_MICROSECONDS](&args);
 }
 
-uint32 utp_call_get_random(utp_context *ctx, utp_socket *socket)
+uint32_t utp_call_get_random(utp_context *ctx, utp_socket *socket)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_GET_RANDOM]) return 0;
 	args.callback_type = UTP_GET_RANDOM;
 	args.context = ctx;
 	args.socket = socket;
-	return (uint32)ctx->callbacks[UTP_GET_RANDOM](&args);
+	return (uint32_t)ctx->callbacks[UTP_GET_RANDOM](&args);
 }
 
 size_t utp_call_get_read_buffer_size(utp_context *ctx, utp_socket *socket)
@@ -191,7 +191,7 @@ void utp_call_log(utp_context *ctx, utp_socket *socket, const byte *buf)
 	ctx->callbacks[UTP_LOG](&args);
 }
 
-void utp_call_sendto(utp_context *ctx, utp_socket *socket, const byte *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32 flags)
+void utp_call_sendto(utp_context *ctx, utp_socket *socket, const byte *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32_t flags)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_SENDTO]) return;

--- a/utp_callbacks.cpp
+++ b/utp_callbacks.cpp
@@ -69,7 +69,7 @@ void utp_call_on_error(utp_context *ctx, utp_socket *socket, int error_code)
 	ctx->callbacks[UTP_ON_ERROR](&args);
 }
 
-void utp_call_on_read(utp_context *ctx, utp_socket *socket, const byte *buf, size_t len)
+void utp_call_on_read(utp_context *ctx, utp_socket *socket, const uint8_t *buf, size_t len)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_ON_READ]) return;
@@ -180,7 +180,7 @@ size_t utp_call_get_read_buffer_size(utp_context *ctx, utp_socket *socket)
 	return (size_t)ctx->callbacks[UTP_GET_READ_BUFFER_SIZE](&args);
 }
 
-void utp_call_log(utp_context *ctx, utp_socket *socket, const byte *buf)
+void utp_call_log(utp_context *ctx, utp_socket *socket, const uint8_t *buf)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_LOG]) return;
@@ -191,7 +191,7 @@ void utp_call_log(utp_context *ctx, utp_socket *socket, const byte *buf)
 	ctx->callbacks[UTP_LOG](&args);
 }
 
-void utp_call_sendto(utp_context *ctx, utp_socket *socket, const byte *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32_t flags)
+void utp_call_sendto(utp_context *ctx, utp_socket *socket, const uint8_t *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32_t flags)
 {
 	utp_callback_arguments args;
 	if (!ctx->callbacks[UTP_SENDTO]) return;

--- a/utp_callbacks.h
+++ b/utp_callbacks.h
@@ -31,7 +31,7 @@ int utp_call_on_firewall(utp_context *ctx, const struct sockaddr *address, sockl
 void utp_call_on_accept(utp_context *ctx, utp_socket *s, const struct sockaddr *address, socklen_t address_len);
 void utp_call_on_connect(utp_context *ctx, utp_socket *s);
 void utp_call_on_error(utp_context *ctx, utp_socket *s, int error_code);
-void utp_call_on_read(utp_context *ctx, utp_socket *s, const byte *buf, size_t len);
+void utp_call_on_read(utp_context *ctx, utp_socket *s, const uint8_t *buf, size_t len);
 void utp_call_on_overhead_statistics(utp_context *ctx, utp_socket *s, int send, size_t len, int type);
 void utp_call_on_delay_sample(utp_context *ctx, utp_socket *s, int sample_ms);
 void utp_call_on_state_change(utp_context *ctx, utp_socket *s, int state);
@@ -41,7 +41,7 @@ uint64_t utp_call_get_milliseconds(utp_context *ctx, utp_socket *s);
 uint64_t utp_call_get_microseconds(utp_context *ctx, utp_socket *s);
 uint32_t utp_call_get_random(utp_context *ctx, utp_socket *s);
 size_t utp_call_get_read_buffer_size(utp_context *ctx, utp_socket *s);
-void utp_call_log(utp_context *ctx, utp_socket *s, const byte *buf);
-void utp_call_sendto(utp_context *ctx, utp_socket *s, const byte *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32_t flags);
+void utp_call_log(utp_context *ctx, utp_socket *s, const uint8_t *buf);
+void utp_call_sendto(utp_context *ctx, utp_socket *s, const uint8_t *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32_t flags);
 
 #endif // __UTP_CALLBACKS_H__

--- a/utp_callbacks.h
+++ b/utp_callbacks.h
@@ -35,13 +35,13 @@ void utp_call_on_read(utp_context *ctx, utp_socket *s, const byte *buf, size_t l
 void utp_call_on_overhead_statistics(utp_context *ctx, utp_socket *s, int send, size_t len, int type);
 void utp_call_on_delay_sample(utp_context *ctx, utp_socket *s, int sample_ms);
 void utp_call_on_state_change(utp_context *ctx, utp_socket *s, int state);
-uint16 utp_call_get_udp_mtu(utp_context *ctx, utp_socket *s, const struct sockaddr *address, socklen_t address_len);
-uint16 utp_call_get_udp_overhead(utp_context *ctx, utp_socket *s, const struct sockaddr *address, socklen_t address_len);
-uint64 utp_call_get_milliseconds(utp_context *ctx, utp_socket *s);
-uint64 utp_call_get_microseconds(utp_context *ctx, utp_socket *s);
-uint32 utp_call_get_random(utp_context *ctx, utp_socket *s);
+uint16_t utp_call_get_udp_mtu(utp_context *ctx, utp_socket *s, const struct sockaddr *address, socklen_t address_len);
+uint16_t utp_call_get_udp_overhead(utp_context *ctx, utp_socket *s, const struct sockaddr *address, socklen_t address_len);
+uint64_t utp_call_get_milliseconds(utp_context *ctx, utp_socket *s);
+uint64_t utp_call_get_microseconds(utp_context *ctx, utp_socket *s);
+uint32_t utp_call_get_random(utp_context *ctx, utp_socket *s);
 size_t utp_call_get_read_buffer_size(utp_context *ctx, utp_socket *s);
 void utp_call_log(utp_context *ctx, utp_socket *s, const byte *buf);
-void utp_call_sendto(utp_context *ctx, utp_socket *s, const byte *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32 flags);
+void utp_call_sendto(utp_context *ctx, utp_socket *s, const byte *buf, size_t len, const struct sockaddr *address, socklen_t address_len, uint32_t flags);
 
 #endif // __UTP_CALLBACKS_H__

--- a/utp_hash.cpp
+++ b/utp_hash.cpp
@@ -26,15 +26,15 @@
 #define LIBUTP_HASH_UNUSED ((utp_link_t)-1)
 
 #ifdef STRICT_ALIGN
-inline uint32 Read32(const void *p)
+inline uint32_t Read32(const void *p)
 {
-	uint32 tmp;
+	uint32_t tmp;
 	memcpy(&tmp, p, sizeof tmp);
 	return tmp;
 }
 
 #else
-inline uint32 Read32(const void *p) { return *(uint32*)p; }
+inline uint32_t Read32(const void *p) { return *(uint32_t*)p; }
 #endif
 
 
@@ -91,7 +91,7 @@ uint utp_hash_mem(const void *keyp, size_t keysize)
 	uint n = keysize;
 	while (n >= 4) {
 		hash ^= Read32(keyp);
-		keyp = (byte*)keyp + sizeof(uint32);
+		keyp = (byte*)keyp + sizeof(uint32_t);
 		hash = (hash << 13) | (hash >> 19);
 		n -= 4;
 	}

--- a/utp_hash.cpp
+++ b/utp_hash.cpp
@@ -85,10 +85,10 @@ utp_hash_t *utp_hash_create(int N, int key_size, int total_size, int initial, ut
 	return hash;
 }
 
-uint utp_hash_mem(const void *keyp, size_t keysize)
+unsigned int utp_hash_mem(const void *keyp, size_t keysize)
 {
-	uint hash = 0;
-	uint n = keysize;
+	unsigned int hash = 0;
+	unsigned int n = keysize;
 	while (n >= 4) {
 		hash ^= Read32(keyp);
 		keyp = (uint8_t*)keyp + sizeof(uint32_t);
@@ -104,7 +104,7 @@ uint utp_hash_mem(const void *keyp, size_t keysize)
 	return hash;
 }
 
-uint utp_hash_mkidx(utp_hash_t *hash, const void *keyp)
+unsigned int utp_hash_mkidx(utp_hash_t *hash, const void *keyp)
 {
 	// Generate a key from the hash
 	return hash->hash_compute(keyp, hash->K) % hash->N;

--- a/utp_hash.cpp
+++ b/utp_hash.cpp
@@ -44,7 +44,7 @@ inline uint32_t Read32(const void *p) { return *(uint32_t*)p; }
 #define BASE_SIZE(bc) (sizeof(utp_hash_t) + sizeof(utp_link_t) * ((bc) + 1))
 
 // Get a pointer to the base of the structure array managed by the hash table
-#define get_bep(h) ((byte*)(h)) + BASE_SIZE((h)->N)
+#define get_bep(h) ((uint8_t*)(h)) + BASE_SIZE((h)->N)
 
 // Get the address of the information associated with a specific structure in the array,
 // given the address of the base of the structure.
@@ -53,7 +53,7 @@ inline uint32_t Read32(const void *p) { return *(uint32_t*)p; }
 // the location named in the structure may not be the location actually used by the hash table,
 // since the compiler may have padded the end of the structure with 2 bytes after the utp_link_t member.
 // TODO: this macro should not require that the variable pointing at the hash table be named 'hash'
-#define ptr_to_link(p) (utp_link_t *) (((byte *) (p)) + hash->E - sizeof(utp_link_t))
+#define ptr_to_link(p) (utp_link_t *) (((uint8_t *) (p)) + hash->E - sizeof(utp_link_t))
 
 // Calculate how much to allocate for a hash table with bucket count, total size, and structure count
 // TODO:  make this 64-bit clean
@@ -91,13 +91,13 @@ uint utp_hash_mem(const void *keyp, size_t keysize)
 	uint n = keysize;
 	while (n >= 4) {
 		hash ^= Read32(keyp);
-		keyp = (byte*)keyp + sizeof(uint32_t);
+		keyp = (uint8_t*)keyp + sizeof(uint32_t);
 		hash = (hash << 13) | (hash >> 19);
 		n -= 4;
 	}
 	while (n != 0) {
-		hash ^= *(byte*)keyp;
-		keyp = (byte*)keyp + sizeof(byte);
+		hash ^= *(uint8_t*)keyp;
+		keyp = (uint8_t*)keyp + sizeof(uint8_t);
 		hash = (hash << 8) | (hash >> 24);
 		n--;
 	}
@@ -110,7 +110,7 @@ uint utp_hash_mkidx(utp_hash_t *hash, const void *keyp)
 	return hash->hash_compute(keyp, hash->K) % hash->N;
 }
 
-static inline bool compare(byte *a, byte *b,int n)
+static inline bool compare(uint8_t *a, uint8_t *b,int n)
 {
 	assert(n >= 4);
 	if (Read32(a) != Read32(b)) return false;
@@ -126,12 +126,12 @@ void *utp_hash_lookup(utp_hash_t *hash, const void *key)
 	utp_link_t idx = utp_hash_mkidx(hash, key);
 
 	// base pointer
-	byte *bep = get_bep(hash);
+	uint8_t *bep = get_bep(hash);
 
 	utp_link_t cur = hash->inits[idx];
 	while (cur != LIBUTP_HASH_UNUSED) {
-		byte *key2 = bep + (cur * hash->E);
-		if (COMPARE(hash, (byte*)key, key2, hash->K))
+		uint8_t *key2 = bep + (cur * hash->E);
+		if (COMPARE(hash, (uint8_t*)key, key2, hash->K))
 			return key2;
 		cur = *ptr_to_link(key2);
 	}
@@ -145,7 +145,7 @@ void *utp_hash_lookup(utp_hash_t *hash, const void *key)
 void *utp_hash_add(utp_hash_t **hashp, const void *key)
 {
 	//Allocate a new entry
-	byte *elemp;
+	uint8_t *elemp;
 	utp_link_t elem;
 	utp_hash_t *hash = *hashp;
 	utp_link_t idx = utp_hash_mkidx(hash, key);
@@ -197,13 +197,13 @@ void *utp_hash_del(utp_hash_t *hash, const void *key)
 	utp_link_t idx = utp_hash_mkidx(hash, key);
 
 	// base pointer
-	byte *bep = get_bep(hash);
+	uint8_t *bep = get_bep(hash);
 
 	utp_link_t *curp = &hash->inits[idx];
 	utp_link_t cur;
 	while ((cur=*curp) != LIBUTP_HASH_UNUSED) {
-		byte *key2 = bep + (cur * hash->E);
-		if (COMPARE(hash,(byte*)key,(byte*)key2, hash->K )) {
+		uint8_t *key2 = bep + (cur * hash->E);
+		if (COMPARE(hash,(uint8_t*)key,(uint8_t*)key2, hash->K )) {
 			// found an item that matched. unlink it
 			*curp = *ptr_to_link(key2);
 			// Insert into freelist
@@ -235,7 +235,7 @@ void *utp_hash_iterate(utp_hash_t *hash, utp_hash_iterator_t *iter)
 		iter->bucket = buck;
 	}
 
-	byte *elemp = get_bep(hash) + (elem * hash->E);
+	uint8_t *elemp = get_bep(hash) + (elem * hash->E);
 	iter->elem = *ptr_to_link(elemp);
 	return elemp;
 }

--- a/utp_hash.h
+++ b/utp_hash.h
@@ -38,7 +38,7 @@ typedef uint32_t utp_link_t;
 #endif
 
 typedef uint32_t (*utp_hash_compute_t)(const void *keyp, size_t keysize);
-typedef uint (*utp_hash_equal_t)(const void *key_a, const void *key_b, size_t keysize);
+typedef unsigned int (*utp_hash_equal_t)(const void *key_a, const void *key_b, size_t keysize);
 
 // In memory the HashTable is laid out as follows:
 //  ---------------------------- low
@@ -98,8 +98,8 @@ struct utp_hash_iterator_t {
 	utp_hash_iterator_t() : bucket(0xffffffff), elem(0xffffffff) {}
 };
 
-uint utp_hash_mem(const void *keyp, size_t keysize);
-uint utp_hash_comp(const void *key_a, const void *key_b, size_t keysize);
+unsigned int utp_hash_mem(const void *keyp, size_t keysize);
+unsigned int utp_hash_comp(const void *key_a, const void *key_b, size_t keysize);
 
 utp_hash_t *utp_hash_create(int N, int key_size, int total_size, int initial, utp_hash_compute_t hashfun = utp_hash_mem, utp_hash_equal_t eqfun = NULL);
 void *utp_hash_lookup(utp_hash_t *hash, const void *key);
@@ -126,7 +126,7 @@ void utp_hash_free_mem(utp_hash_t *hash);
 template<typename K, typename T> class utpHashTable {
 	utp_hash_t *hash;
 public:
-	static uint compare(const void *k1, const void *k2, size_t ks) {
+	static unsigned int compare(const void *k1, const void *k2, size_t ks) {
 		return *((K*)k1) == *((K*)k2);
 	}
 	static uint32_t compute_hash(const void *k, size_t ks) {

--- a/utp_hash.h
+++ b/utp_hash.h
@@ -76,8 +76,8 @@ typedef uint (*utp_hash_equal_t)(const void *key_a, const void *key_b, size_t ke
 //
 struct utp_hash_t {
 	utp_link_t N;
-	byte K;
-	byte E;
+	uint8_t K;
+	uint8_t E;
 	size_t count;
 	utp_hash_compute_t hash_compute;
 	utp_hash_equal_t hash_equal;

--- a/utp_hash.h
+++ b/utp_hash.h
@@ -30,14 +30,14 @@
 #include "utp_templates.h"
 
 // TODO: make utp_link_t a template parameter to HashTable
-typedef uint32 utp_link_t;
+typedef uint32_t utp_link_t;
 
 #ifdef _MSC_VER
 // Silence the warning about the C99-compliant zero-length array at the end of the structure
 #pragma warning (disable: 4200)
 #endif
 
-typedef uint32 (*utp_hash_compute_t)(const void *keyp, size_t keysize);
+typedef uint32_t (*utp_hash_compute_t)(const void *keyp, size_t keysize);
 typedef uint (*utp_hash_equal_t)(const void *key_a, const void *key_b, size_t keysize);
 
 // In memory the HashTable is laid out as follows:
@@ -129,7 +129,7 @@ public:
 	static uint compare(const void *k1, const void *k2, size_t ks) {
 		return *((K*)k1) == *((K*)k2);
 	}
-	static uint32 compute_hash(const void *k, size_t ks) {
+	static uint32_t compute_hash(const void *k, size_t ks) {
 		return ((K*)k)->compute_hash();
 	}
 	void Init() { hash = NULL; }

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
@@ -760,7 +761,7 @@ void UTPSocket::send_data(byte* b, size_t length, bandwidth_type_t type, uint32_
 	int flags2 = b1->type();
 	uint16_t seq_nr = b1->seq_nr;
 	uint16_t ack_nr = b1->ack_nr;
-	log(UTP_LOG_DEBUG, "send %s len:%u id:%u timestamp:" I64u " reply_micro:%u flags:%s seq_nr:%u ack_nr:%u",
+	log(UTP_LOG_DEBUG, "send %s len:%u id:%u timestamp:" PRIu64 " reply_micro:%u flags:%s seq_nr:%u ack_nr:%u",
 		addrfmt(addr, addrbuf), (uint)length, conn_id_send, time, reply_micro, flagnames[flags2],
 		seq_nr, ack_nr);
 #endif
@@ -1712,11 +1713,11 @@ void UTPSocket::apply_ccontrol(size_t bytes_acked, uint32_t actual_delay, int64_
 	// used in parse_log.py
 	log(UTP_LOG_NORMAL, "actual_delay:%u our_delay:%d their_delay:%u off_target:%d max_window:%u "
 			"delay_base:%u delay_sum:%d target_delay:%d acked_bytes:%u cur_window:%u "
-			"scaled_gain:%f rtt:%u rate:%u wnduser:%u rto:%u timeout:%d get_microseconds:" I64u " "
+			"scaled_gain:%f rtt:%u rate:%u wnduser:%u rto:%u timeout:%d get_microseconds:" PRIu64 " "
 			"cur_window_packets:%u packet_size:%u their_delay_base:%u their_actual_delay:%u "
-			"average_delay:%d clock_drift:%d clock_drift_raw:%d delay_penalty:%d current_delay_sum:" I64u
-			"current_delay_samples:%d average_delay_base:%d last_maxed_out_window:" I64u " opt_sndbuf:%d "
-			"current_ms:" I64u "",
+			"average_delay:%d clock_drift:%d clock_drift_raw:%d delay_penalty:%d current_delay_sum:" PRIu64
+			"current_delay_samples:%d average_delay_base:%d last_maxed_out_window:" PRIu64 " opt_sndbuf:%d "
+			"current_ms:" PRIu64 "",
 			actual_delay, our_delay / 1000, their_hist.get_value() / 1000,
 			int(off_target / 1000), uint(max_window), uint32_t(our_hist.delay_base),
 			int((our_delay + their_hist.get_value()) / 1000), int(target / 1000), uint(bytes_acked),
@@ -1780,7 +1781,7 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 	if (pk_flags >= ST_NUM_STATES) return 0;
 
 	#if UTP_DEBUG_LOGGING
-	conn->log(UTP_LOG_DEBUG, "Got %s. seq_nr:%u ack_nr:%u state:%s timestamp:" I64u " reply_micro:%u"
+	conn->log(UTP_LOG_DEBUG, "Got %s. seq_nr:%u ack_nr:%u state:%s timestamp:" PRIu64 " reply_micro:%u"
 		, flagnames[pk_flags], pk_seq_nr, pk_ack_nr, statenames[conn->state]
 		, uint64_t(pf1->tv_usec), (uint32_t)(pf1->reply_micro));
 	#endif

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -176,7 +176,7 @@ static const cstr statenames[] = {
 struct OutgoingPacket {
 	size_t length;
 	size_t payload;
-	uint64 time_sent; // microseconds
+	uint64_t time_sent; // microseconds
 	uint transmissions:31;
 	bool need_resend:1;
 	byte data[1];
@@ -224,12 +224,12 @@ void SizableCircularBuffer::grow(size_t item, size_t index)
 // into account. if lhs is close to UINT_MAX and rhs
 // is close to 0, lhs is assumed to have wrapped and
 // considered smaller
-bool wrapping_compare_less(uint32 lhs, uint32 rhs, uint32 mask)
+bool wrapping_compare_less(uint32_t lhs, uint32_t rhs, uint32_t mask)
 {
 	// distance walking from lhs to rhs, downwards
-	const uint32 dist_down = (lhs - rhs) & mask;
+	const uint32_t dist_down = (lhs - rhs) & mask;
 	// distance walking from lhs to rhs, upwards
-	const uint32 dist_up = (rhs - lhs) & mask;
+	const uint32_t dist_up = (rhs - lhs) & mask;
 
 	// if the distance walking up is shorter, lhs
 	// is less than rhs. If the distance walking down
@@ -238,13 +238,13 @@ bool wrapping_compare_less(uint32 lhs, uint32 rhs, uint32 mask)
 }
 
 struct DelayHist {
-	uint32 delay_base;
+	uint32_t delay_base;
 
 	// this is the history of delay samples,
 	// normalized by using the delay_base. These
 	// values are always greater than 0 and measures
 	// the queuing delay in microseconds
-	uint32 cur_delay_hist[CUR_DELAY_SIZE];
+	uint32_t cur_delay_hist[CUR_DELAY_SIZE];
 	size_t cur_delay_idx;
 
 	// this is the history of delay_base. It's
@@ -252,14 +252,14 @@ struct DelayHist {
 	// only relative. It doesn't make sense to initialize
 	// it to anything other than values relative to
 	// what's been seen in the real world.
-	uint32 delay_base_hist[DELAY_BASE_HISTORY];
+	uint32_t delay_base_hist[DELAY_BASE_HISTORY];
 	size_t delay_base_idx;
 	// the time when we last stepped the delay_base_idx
-	uint64 delay_base_time;
+	uint64_t delay_base_time;
 
 	bool delay_base_initialized;
 
-	void clear(uint64 current_ms)
+	void clear(uint64_t current_ms)
 	{
 		delay_base_initialized = false;
 		delay_base = 0;
@@ -274,7 +274,7 @@ struct DelayHist {
 		}
 	}
 
-	void shift(const uint32 offset)
+	void shift(const uint32_t offset)
 	{
 		// the offset should never be "negative"
 		// assert(offset < 0x10000000);
@@ -288,7 +288,7 @@ struct DelayHist {
 		delay_base += offset;
 	}
 
-	void add_sample(const uint32 sample, uint64 current_ms)
+	void add_sample(const uint32_t sample, uint64_t current_ms)
 	{
 		// The two clocks (in the two peers) are assumed not to
 		// progress at the exact same rate. They are assumed to be
@@ -356,7 +356,7 @@ struct DelayHist {
 		}
 
 		// this operation may wrap, and is supposed to
-		const uint32 delay = sample - delay_base;
+		const uint32_t delay = sample - delay_base;
 		// sanity check. If this is triggered, something fishy is going on
 		// it means the measured sample was greater than 32 seconds!
 		//assert(delay < 0x2000000);
@@ -380,11 +380,11 @@ struct DelayHist {
 		}
 	}
 
-	uint32 get_value()
+	uint32_t get_value()
 	{
-		uint32 value = UINT_MAX;
+		uint32_t value = UINT_MAX;
 		for (size_t i = 0; i < CUR_DELAY_SIZE; i++) {
-			value = min<uint32>(cur_delay_hist[i], value);
+			value = min<uint32_t>(cur_delay_hist[i], value);
 		}
 		// value could be UINT_MAX if we have no samples yet...
 		return value;
@@ -399,15 +399,15 @@ struct UTPSocket {
 
 	int ida; //for ack socket list
 
-	uint16 retransmit_count;
+	uint16_t retransmit_count;
 
-	uint16 reorder_count;
+	uint16_t reorder_count;
 	byte duplicate_ack;
 
 	// the number of packets in the send queue. Packets that haven't
 	// yet been sent count as well as packets marked as needing resend
 	// the oldest un-acked packet in the send queue is seq_nr - cur_window_packets
-	uint16 cur_window_packets;
+	uint16_t cur_window_packets;
 
 	// how much of the window is used, number of bytes in-flight
 	// packets that have not yet been sent do not count, packets
@@ -447,38 +447,38 @@ struct UTPSocket {
 	size_t max_window_user;
 	CONN_STATE state;
 	// TickCount when we last decayed window (wraps)
-	int64 last_rwin_decay;
+	int64_t last_rwin_decay;
 
 	// the sequence number of the FIN packet. This field is only set
 	// when we have received a FIN, and the flag field has the FIN flag set.
 	// it is used to know when it is safe to destroy the socket, we must have
 	// received all packets up to this sequence number first.
-	uint16 eof_pkt;
+	uint16_t eof_pkt;
 
 	// All sequence numbers up to including this have been properly received
 	// by us
-	uint16 ack_nr;
+	uint16_t ack_nr;
 	// This is the sequence number for the next packet to be sent.
-	uint16 seq_nr;
+	uint16_t seq_nr;
 
-	uint16 timeout_seq_nr;
+	uint16_t timeout_seq_nr;
 
 	// This is the sequence number of the next packet we're allowed to
 	// do a fast resend with. This makes sure we only do a fast-resend
 	// once per packet. We can resend the packet with this sequence number
 	// or any later packet (with a higher sequence number).
-	uint16 fast_resend_seq_nr;
+	uint16_t fast_resend_seq_nr;
 
-	uint32 reply_micro;
+	uint32_t reply_micro;
 
-	uint64 last_got_packet;
-	uint64 last_sent_packet;
-	uint64 last_measured_delay;
+	uint64_t last_got_packet;
+	uint64_t last_sent_packet;
+	uint64_t last_measured_delay;
 
 	// timestamp of the last time the cwnd was full
 	// this is used to prevent the congestion window
 	// from growing when we're not sending at capacity
-	mutable uint64 last_maxed_out_window;
+	mutable uint64_t last_maxed_out_window;
 
 	void *userdata;
 
@@ -491,15 +491,15 @@ struct UTPSocket {
 	DelayHist rtt_hist;
 	uint retransmit_timeout;
 	// The RTO timer will timeout here.
-	uint64 rto_timeout;
+	uint64_t rto_timeout;
 	// When the window size is set to zero, start this timer. It will send a new packet every 30secs.
-	uint64 zerowindow_time;
+	uint64_t zerowindow_time;
 
-	uint32 conn_seed;
+	uint32_t conn_seed;
 	// Connection ID for packets I receive
-	uint32 conn_id_recv;
+	uint32_t conn_id_recv;
 	// Connection ID for packets I send
-	uint32 conn_id_send;
+	uint32_t conn_id_send;
 	// Last rcv window we advertised, in bytes
 	size_t last_rcv_win;
 
@@ -511,40 +511,40 @@ struct UTPSocket {
 
 	// MTU Discovery
 	// time when we should restart the MTU discovery
-	uint64 mtu_discover_time;
+	uint64_t mtu_discover_time;
 	// ceiling and floor of binary search. last is the mtu size
 	// we're currently using
-	uint32 mtu_ceiling, mtu_floor, mtu_last;
+	uint32_t mtu_ceiling, mtu_floor, mtu_last;
 	// we only ever have a single probe in flight at any given time.
 	// this is the sequence number of that probe, and the size of
 	// that packet
-	uint32 mtu_probe_seq, mtu_probe_size;
+	uint32_t mtu_probe_seq, mtu_probe_size;
 
 	// this is the average delay samples, as compared to the initial
 	// sample. It's averaged over 5 seconds
-	int32 average_delay;
+	int32_t average_delay;
 	// this is the sum of all the delay samples
 	// we've made recently. The important distinction
 	// of these samples is that they are all made compared
 	// to the initial sample, this is to deal with
 	// wrapping in a simple way.
-	int64 current_delay_sum;
+	int64_t current_delay_sum;
 	// number of sample ins current_delay_sum
 	int current_delay_samples;
 	// initialized to 0, set to the first raw delay sample
 	// each sample that's added to current_delay_sum
 	// is subtracted from the value first, to make it
 	// a delay relative to this sample
-	uint32 average_delay_base;
+	uint32_t average_delay_base;
 	// the next time we should add an average delay
 	// sample into average_delay_hist
-	uint64 average_sample_time;
+	uint64_t average_sample_time;
 	// the estimated clock drift between our computer
 	// and the endpoint computer. The unit is microseconds
 	// per 5 seconds
-	int32 clock_drift;
+	int32_t clock_drift;
 	// just used for logging
-	int32 clock_drift_raw;
+	int32_t clock_drift_raw;
 
 	SizableCircularBuffer inbuf, outbuf;
 
@@ -599,13 +599,13 @@ struct UTPSocket {
 	// XXX this breaks when spaced by > INT_MAX/2, which is 49
 	// days; the failure mode in that case is we do an extra decay
 	// or fail to do one when we really shouldn't.
-	bool can_decay_win(int64 msec) const
+	bool can_decay_win(int64_t msec) const
 	{
                 return (msec - last_rwin_decay) >= MAX_WINDOW_DECAY;
 	}
 
 	// If we can, decay max window, returns true if we actually did so
-	void maybe_decay_win(uint64 current_ms)
+	void maybe_decay_win(uint64_t current_ms)
 	{
 		if (can_decay_win(current_ms)) {
 			// TCP uses 0.5
@@ -642,15 +642,15 @@ struct UTPSocket {
 		return get_udp_overhead() + get_header_size();
 	}
 
-	void send_data(byte* b, size_t length, bandwidth_type_t type, uint32 flags = 0);
+	void send_data(byte* b, size_t length, bandwidth_type_t type, uint32_t flags = 0);
 
 	void send_ack(bool synack = false);
 
 	void send_keep_alive();
 
 	static void send_rst(utp_context *ctx,
-						 const PackedSockAddr &addr, uint32 conn_id_send,
-						 uint16 ack_nr, uint16 seq_nr);
+						 const PackedSockAddr &addr, uint32_t conn_id_send,
+						 uint16_t ack_nr, uint16_t seq_nr);
 
 	void send_packet(OutgoingPacket *pkt);
 
@@ -663,10 +663,10 @@ struct UTPSocket {
 	#endif
 
 	void check_timeouts();
-	int ack_packet(uint16 seq);
-	size_t selective_ack_bytes(uint base, const byte* mask, byte len, int64& min_rtt);
+	int ack_packet(uint16_t seq);
+	size_t selective_ack_bytes(uint base, const byte* mask, byte len, int64_t& min_rtt);
 	void selective_ack(uint base, const byte *mask, byte len);
-	void apply_ccontrol(size_t bytes_acked, uint32 actual_delay, int64 min_rtt);
+	void apply_ccontrol(size_t bytes_acked, uint32_t actual_delay, int64_t min_rtt);
 	size_t get_packet_size() const;
 };
 
@@ -726,15 +726,15 @@ void UTPSocket::schedule_ack()
 	}
 }
 
-void UTPSocket::send_data(byte* b, size_t length, bandwidth_type_t type, uint32 flags)
+void UTPSocket::send_data(byte* b, size_t length, bandwidth_type_t type, uint32_t flags)
 {
 	// time stamp this packet with local time, the stamp goes into
 	// the header of every packet at the 8th byte for 8 bytes :
 	// two integers, check packet.h for more
-	uint64 time = utp_call_get_microseconds(ctx, this);
+	uint64_t time = utp_call_get_microseconds(ctx, this);
 
 	PacketFormatV1* b1 = (PacketFormatV1*)b;
-	b1->tv_usec = (uint32)time;
+	b1->tv_usec = (uint32_t)time;
 	b1->reply_micro = reply_micro;
 
 	last_sent_packet = ctx->current_ms;
@@ -758,8 +758,8 @@ void UTPSocket::send_data(byte* b, size_t length, bandwidth_type_t type, uint32 
 	}
 #if UTP_DEBUG_LOGGING
 	int flags2 = b1->type();
-	uint16 seq_nr = b1->seq_nr;
-	uint16 ack_nr = b1->ack_nr;
+	uint16_t seq_nr = b1->seq_nr;
+	uint16_t ack_nr = b1->ack_nr;
 	log(UTP_LOG_DEBUG, "send %s len:%u id:%u timestamp:" I64u " reply_micro:%u flags:%s seq_nr:%u ack_nr:%u",
 		addrfmt(addr, addrbuf), (uint)length, conn_id_send, time, reply_micro, flagnames[flags2],
 		seq_nr, ack_nr);
@@ -781,7 +781,7 @@ void UTPSocket::send_ack(bool synack)
 	pfa.pf.connid = conn_id_send;
 	pfa.pf.ack_nr = ack_nr;
 	pfa.pf.seq_nr = seq_nr;
-	pfa.pf.windowsize = (uint32)last_rcv_win;
+	pfa.pf.windowsize = (uint32_t)last_rcv_win;
 	len = sizeof(PacketFormatV1);
 
 	// we never need to send EACK for connections
@@ -844,7 +844,7 @@ void UTPSocket::send_keep_alive()
 }
 
 void UTPSocket::send_rst(utp_context *ctx,
-	const PackedSockAddr &addr, uint32 conn_id_send, uint16 ack_nr, uint16 seq_nr)
+	const PackedSockAddr &addr, uint32_t conn_id_send, uint16_t ack_nr, uint16_t seq_nr)
 {
 	PacketFormatV1 pf1;
 	zeromem(&pf1);
@@ -889,7 +889,7 @@ void UTPSocket::send_packet(OutgoingPacket *pkt)
 	bool use_as_mtu_probe = false;
 
 	// TODO: this is subject to nasty wrapping issues! Below as well
- 	if (mtu_discover_time < (uint64)cur_time) {
+ 	if (mtu_discover_time < (uint64_t)cur_time) {
 		// it's time to reset our MTU assupmtions
 		// and trigger a new search
 		mtu_reset();
@@ -967,7 +967,7 @@ bool UTPSocket::flush_packets()
 	// send packets that are waiting on the pacer to be sent
 	// i has to be an unsigned 16 bit counter to wrap correctly
 	// signed types are not guaranteed to wrap the way you expect
-	for (uint16 i = seq_nr - cur_window_packets; i != seq_nr; ++i) {
+	for (uint16_t i = seq_nr - cur_window_packets; i != seq_nr; ++i) {
 		OutgoingPacket *pkt = (OutgoingPacket*)outbuf.get(i);
 		if (pkt == 0 || (pkt->transmissions > 0 && pkt->need_resend == false)) continue;
 		// have we run out of quota?
@@ -1079,7 +1079,7 @@ void UTPSocket::write_outgoing_packet(size_t payload, uint flags, struct utp_iov
 		p1->set_type(flags);
 		p1->ext = 0;
 		p1->connid = conn_id_send;
-		p1->windowsize = (uint32)last_rcv_win;
+		p1->windowsize = (uint32_t)last_rcv_win;
 		p1->ack_nr = ack_nr;
 
 		if (append) {
@@ -1326,7 +1326,7 @@ void UTPSocket::mtu_reset()
 // 0: the packet was acked.
 // 1: it means that the packet had already been acked
 // 2: the packet has not been sent yet
-int UTPSocket::ack_packet(uint16 seq)
+int UTPSocket::ack_packet(uint16_t seq)
 {
 	OutgoingPacket *pkt = (OutgoingPacket*)outbuf.get(seq);
 
@@ -1361,7 +1361,7 @@ int UTPSocket::ack_packet(uint16 seq)
 	// if we never re-sent the packet, update the RTT estimate
 	if (pkt->transmissions == 1) {
 		// Estimate the round trip time.
-		const uint32 ertt = (uint32)((utp_call_get_microseconds(this->ctx, this) - pkt->time_sent) / 1000);
+		const uint32_t ertt = (uint32_t)((utp_call_get_microseconds(this->ctx, this) - pkt->time_sent) / 1000);
 		if (rtt == 0) {
 			// First round trip time sample
 			rtt = ertt;
@@ -1400,20 +1400,20 @@ int UTPSocket::ack_packet(uint16 seq)
 }
 
 // count the number of bytes that were acked by the EACK header
-size_t UTPSocket::selective_ack_bytes(uint base, const byte* mask, byte len, int64& min_rtt)
+size_t UTPSocket::selective_ack_bytes(uint base, const byte* mask, byte len, int64_t& min_rtt)
 {
 	if (cur_window_packets == 0) return 0;
 
 	size_t acked_bytes = 0;
 	int bits = len * 8;
-	uint64 now = utp_call_get_microseconds(this->ctx, this);
+	uint64_t now = utp_call_get_microseconds(this->ctx, this);
 
 	do {
 		uint v = base + bits;
 
 		// ignore bits that haven't been sent yet
 		// see comment in UTPSocket::selective_ack
-		if (((seq_nr - v - 1) & ACK_NR_MASK) >= (uint16)(cur_window_packets - 1))
+		if (((seq_nr - v - 1) & ACK_NR_MASK) >= (uint16_t)(cur_window_packets - 1))
 			continue;
 
 		// ignore bits that represents packets we haven't sent yet
@@ -1427,9 +1427,9 @@ size_t UTPSocket::selective_ack_bytes(uint base, const byte* mask, byte len, int
 			assert((int)(pkt->payload) >= 0);
 			acked_bytes += pkt->payload;
 			if (pkt->time_sent < now)
-				min_rtt = min<int64>(min_rtt, now - pkt->time_sent);
+				min_rtt = min<int64_t>(min_rtt, now - pkt->time_sent);
 			else
-				min_rtt = min<int64>(min_rtt, 50000);
+				min_rtt = min<int64_t>(min_rtt, 50000);
 			continue;
 		}
 	} while (--bits >= -1);
@@ -1499,7 +1499,7 @@ void UTPSocket::selective_ack(uint base, const byte *mask, byte len)
 		//              |              |
 		//        (seq_nr-wnd)         seq_nr
 
-		if (((seq_nr - v - 1) & ACK_NR_MASK) >= (uint16)(cur_window_packets - 1))
+		if (((seq_nr - v - 1) & ACK_NR_MASK) >= (uint16_t)(cur_window_packets - 1))
 			continue;
 
 		// this counts as a duplicate ack, even though we might have
@@ -1612,13 +1612,13 @@ void UTPSocket::selective_ack(uint base, const byte *mask, byte len)
 	duplicate_ack = count;
 }
 
-void UTPSocket::apply_ccontrol(size_t bytes_acked, uint32 actual_delay, int64 min_rtt)
+void UTPSocket::apply_ccontrol(size_t bytes_acked, uint32_t actual_delay, int64_t min_rtt)
 {
 	// the delay can never be greater than the rtt. The min_rtt
 	// variable is the RTT in microseconds
 
 	assert(min_rtt >= 0);
-	int32 our_delay = min<uint32>(our_hist.get_value(), uint32(min_rtt));
+	int32_t our_delay = min<uint32_t>(our_hist.get_value(), uint32_t(min_rtt));
 	assert(our_delay != INT_MAX);
 	assert(our_delay >= 0);
 
@@ -1643,7 +1643,7 @@ void UTPSocket::apply_ccontrol(size_t bytes_acked, uint32 actual_delay, int64 mi
 	// and this definitely catches that without any risk of false positives
 	// if clock_drift < -200000 start applying a penalty delay proportional
 	// to how far beoynd -200000 the clock drift is
-	int32 penalty = 0;
+	int32_t penalty = 0;
 	if (clock_drift < -200000) {
 		penalty = (-clock_drift - 200000) / 7;
 		our_delay += penalty;
@@ -1718,7 +1718,7 @@ void UTPSocket::apply_ccontrol(size_t bytes_acked, uint32 actual_delay, int64 mi
 			"current_delay_samples:%d average_delay_base:%d last_maxed_out_window:" I64u " opt_sndbuf:%d "
 			"current_ms:" I64u "",
 			actual_delay, our_delay / 1000, their_hist.get_value() / 1000,
-			int(off_target / 1000), uint(max_window), uint32(our_hist.delay_base),
+			int(off_target / 1000), uint(max_window), uint32_t(our_hist.delay_base),
 			int((our_delay + their_hist.get_value()) / 1000), int(target / 1000), uint(bytes_acked),
 			(uint)(cur_window - bytes_acked), (float)(scaled_gain), rtt,
 			(uint)(max_window * 1000 / (rtt_hist.delay_base?rtt_hist.delay_base:50)),
@@ -1727,7 +1727,7 @@ void UTPSocket::apply_ccontrol(size_t bytes_acked, uint32 actual_delay, int64 mi
 			their_hist.delay_base, their_hist.delay_base + their_hist.get_value(),
 			average_delay, clock_drift, clock_drift_raw, penalty / 1000,
 			current_delay_sum, current_delay_samples, average_delay_base,
-			uint64(last_maxed_out_window), int(opt_sndbuf), uint64(ctx->current_ms));
+			uint64_t(last_maxed_out_window), int(opt_sndbuf), uint64_t(ctx->current_ms));
 }
 
 static void utp_register_recv_packet(UTPSocket *conn, size_t len)
@@ -1773,25 +1773,25 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 	const PacketFormatV1 *pf1 = (PacketFormatV1*)packet;
 	const byte *packet_end = packet + len;
 
-	uint16 pk_seq_nr = pf1->seq_nr;
-	uint16 pk_ack_nr = pf1->ack_nr;
-	uint8 pk_flags   = pf1->type();
+	uint16_t pk_seq_nr = pf1->seq_nr;
+	uint16_t pk_ack_nr = pf1->ack_nr;
+	uint8_t pk_flags   = pf1->type();
 
 	if (pk_flags >= ST_NUM_STATES) return 0;
 
 	#if UTP_DEBUG_LOGGING
 	conn->log(UTP_LOG_DEBUG, "Got %s. seq_nr:%u ack_nr:%u state:%s timestamp:" I64u " reply_micro:%u"
 		, flagnames[pk_flags], pk_seq_nr, pk_ack_nr, statenames[conn->state]
-		, uint64(pf1->tv_usec), (uint32)(pf1->reply_micro));
+		, uint64_t(pf1->tv_usec), (uint32_t)(pf1->reply_micro));
 	#endif
 
 	// mark receipt time
-	uint64 time = utp_call_get_microseconds(conn->ctx, conn);
+	uint64_t time = utp_call_get_microseconds(conn->ctx, conn);
 
 	// window packets size is used to calculate a minimum
 	// permissible range for received acks. connections with acks falling
 	// out of this range are dropped
-	const uint16 curr_window = max<uint16>(conn->cur_window_packets + ACK_NR_ALLOWED_WINDOW, ACK_NR_ALLOWED_WINDOW);
+	const uint16_t curr_window = max<uint16_t>(conn->cur_window_packets + ACK_NR_ALLOWED_WINDOW, ACK_NR_ALLOWED_WINDOW);
 
 	// ignore packets whose ack_nr is invalid. This would imply a spoofed address
 	// or a malicious attempt to attach the uTP implementation.
@@ -1956,9 +1956,9 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 	// from the other peer. Our delay cannot exceed
 	// the rtt of the packet. If it does, clamp it.
 	// this is done in apply_ledbat_ccontrol()
-	int64 min_rtt = INT64_MAX;
+	int64_t min_rtt = INT64_MAX;
 
-	uint64 now = utp_call_get_microseconds(conn->ctx, conn);
+	uint64_t now = utp_call_get_microseconds(conn->ctx, conn);
 
 	for (int i = 0; i < acks; ++i) {
 		int seq = (conn->seq_nr - conn->cur_window_packets + i) & ACK_NR_MASK;
@@ -1975,9 +1975,9 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 
 		// in case our clock is not monotonic
 		if (pkt->time_sent < now)
-			min_rtt = min<int64>(min_rtt, now - pkt->time_sent);
+			min_rtt = min<int64_t>(min_rtt, now - pkt->time_sent);
 		else
-			min_rtt = min<int64>(min_rtt, 50000);
+			min_rtt = min<int64_t>(min_rtt, 50000);
 	}
 
 	// count bytes acked by EACK
@@ -1992,15 +1992,15 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 		seqnr, (uint)conn->max_window, (uint)(min_rtt / 1000), conn->rtt);
 	#endif
 
-	uint64 p = pf1->tv_usec;
+	uint64_t p = pf1->tv_usec;
 
 	conn->last_measured_delay = conn->ctx->current_ms;
 
 	// get delay in both directions
 	// record the delay to report back
-	const uint32 their_delay = (uint32)(p == 0 ? 0 : time - p);
+	const uint32_t their_delay = (uint32_t)(p == 0 ? 0 : time - p);
 	conn->reply_micro = their_delay;
-	uint32 prev_delay_base = conn->their_hist.delay_base;
+	uint32_t prev_delay_base = conn->their_hist.delay_base;
 	if (their_delay != 0) conn->their_hist.add_sample(their_delay, conn->ctx->current_ms);
 
 	// if their new delay base is less than their previous one
@@ -2014,7 +2014,7 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 		}
 	}
 
-	const uint32 actual_delay = (uint32(pf1->reply_micro)==INT_MAX?0:uint32(pf1->reply_micro));
+	const uint32_t actual_delay = (uint32_t(pf1->reply_micro)==INT_MAX?0:uint32_t(pf1->reply_micro));
 
 	// if the actual delay is 0, it means the other end
 	// hasn't received a sample from us yet, and doesn't
@@ -2030,11 +2030,11 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 		// are based off of the average_delay_base to deal with
 		// wrapping counters.
 		if (conn->average_delay_base == 0) conn->average_delay_base = actual_delay;
-		int64 average_delay_sample = 0;
+		int64_t average_delay_sample = 0;
 		// distance walking from lhs to rhs, downwards
-		const uint32 dist_down = conn->average_delay_base - actual_delay;
+		const uint32_t dist_down = conn->average_delay_base - actual_delay;
 		// distance walking from lhs to rhs, upwards
-		const uint32 dist_up = actual_delay - conn->average_delay_base;
+		const uint32_t dist_up = actual_delay - conn->average_delay_base;
 
 		if (dist_down > dist_up) {
 //			assert(dist_up < INT_MAX / 4);
@@ -2042,22 +2042,22 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 			// with a positive sample
 			average_delay_sample = dist_up;
 		} else {
-//			assert(-int64(dist_down) < INT_MAX / 4);
+//			assert(-int64_t(dist_down) < INT_MAX / 4);
 			// average_delay_base >= actual_delay, we should end up
 			// with a negative sample
-			average_delay_sample = -int64(dist_down);
+			average_delay_sample = -int64_t(dist_down);
 		}
 		conn->current_delay_sum += average_delay_sample;
 		++conn->current_delay_samples;
 
 		if (conn->ctx->current_ms > conn->average_sample_time) {
 
-			int32 prev_average_delay = conn->average_delay;
+			int32_t prev_average_delay = conn->average_delay;
 
 			assert(conn->current_delay_sum / conn->current_delay_samples < INT_MAX);
 			assert(conn->current_delay_sum / conn->current_delay_samples > -INT_MAX);
 			// write the new average
-			conn->average_delay = (int32)(conn->current_delay_sum / conn->current_delay_samples);
+			conn->average_delay = (int32_t)(conn->current_delay_sum / conn->current_delay_samples);
 			// each slot represents 5 seconds
 			conn->average_sample_time += 5000;
 
@@ -2098,11 +2098,11 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 			// the average slope across our history. If there is a consistent
 			// trend, it will show up in this value
 
-			//int64 slope = 0;
-			int32 drift = conn->average_delay - prev_average_delay;
+			//int64_t slope = 0;
+			int32_t drift = conn->average_delay - prev_average_delay;
 
 			// clock_drift is a rolling average
-			conn->clock_drift = (int64(conn->clock_drift) * 7 + drift) / 8;
+			conn->clock_drift = (int64_t(conn->clock_drift) * 7 + drift) / 8;
 			conn->clock_drift_raw = drift;
 		}
 	}
@@ -2129,8 +2129,8 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 	// if the delay estimate exceeds the RTT, adjust the base_delay to
 	// compensate
 	assert(min_rtt >= 0);
-	if (int64(conn->our_hist.get_value()) > min_rtt) {
-		conn->our_hist.shift((uint32)(conn->our_hist.get_value() - min_rtt));
+	if (int64_t(conn->our_hist.get_value()) > min_rtt) {
+		conn->our_hist.shift((uint32_t)(conn->our_hist.get_value() - min_rtt));
 	}
 
 	// only apply the congestion controller on acks
@@ -2524,9 +2524,9 @@ void utp_initialize_socket(	utp_socket *conn,
 							const struct sockaddr *addr,
 							socklen_t addrlen,
 							bool need_seed_gen,
-							uint32 conn_seed,
-							uint32 conn_id_recv,
-							uint32 conn_id_send)
+							uint32_t conn_seed,
+							uint32_t conn_id_recv,
+							uint32_t conn_id_send)
 {
 	PackedSockAddr psaddr = PackedSockAddr((const SOCKADDR_STORAGE*)addr, addrlen);
 
@@ -2780,7 +2780,7 @@ int utp_connect(utp_socket *conn, const struct sockaddr *to, socklen_t tolen)
 	p1->set_type(ST_SYN);
 	p1->ext = 0;
 	p1->connid = conn->conn_id_recv;
-	p1->windowsize = (uint32)conn->last_rcv_win;
+	p1->windowsize = (uint32_t)conn->last_rcv_win;
 	p1->seq_nr = conn->seq_nr;
 	pkt->transmissions = 0;
 	pkt->length = header_size;
@@ -2830,7 +2830,7 @@ int utp_process_udp(utp_context *ctx, const byte *buffer, size_t len, const stru
 
 	const PacketFormatV1 *pf1 = (PacketFormatV1*)buffer;
 	const byte version = UTP_Version(pf1);
-	const uint32 id = uint32(pf1->connid);
+	const uint32_t id = uint32_t(pf1->connid);
 
 	if (version != 1) {
 		#if UTP_DEBUG_LOGGING
@@ -2906,7 +2906,7 @@ int utp_process_udp(utp_context *ctx, const byte *buffer, size_t len, const stru
 	}
 
 	// We have not found a matching utp_socket, and this isn't a SYN.  Reject it.
-	const uint32 seq_nr = pf1->seq_nr;
+	const uint32_t seq_nr = pf1->seq_nr;
 	if (flags != ST_SYN) {
 		ctx->current_ms = utp_call_get_milliseconds(ctx, NULL);
 
@@ -3042,7 +3042,7 @@ static UTPSocket* parse_icmp_payload(utp_context *ctx, const byte *buffer, size_
 
 	const PacketFormatV1 *pf = (PacketFormatV1*)buffer;
 	const byte version = UTP_Version(pf);
-	const uint32 id = uint32(pf->connid);
+	const uint32_t id = uint32_t(pf->connid);
 
 	if (version != 1) {
 		#if UTP_DEBUG_LOGGING
@@ -3076,14 +3076,14 @@ static UTPSocket* parse_icmp_payload(utp_context *ctx, const byte *buffer, size_
 // @to: destination address of the original UDP pakcet
 // @tolen: address length
 // @next_hop_mtu: 
-int utp_process_icmp_fragmentation(utp_context *ctx, const byte* buffer, size_t len, const struct sockaddr *to, socklen_t tolen, uint16 next_hop_mtu)
+int utp_process_icmp_fragmentation(utp_context *ctx, const byte* buffer, size_t len, const struct sockaddr *to, socklen_t tolen, uint16_t next_hop_mtu)
 {
 	UTPSocket* conn = parse_icmp_payload(ctx, buffer, len, to, tolen);
 	if (!conn) return 0;
 
 	// Constrain the next_hop_mtu to sane values.  It might not be initialized or sent properly
 	if (next_hop_mtu >= 576 && next_hop_mtu < 0x2000) {
-		conn->mtu_ceiling = min<uint32>(next_hop_mtu, conn->mtu_ceiling);
+		conn->mtu_ceiling = min<uint32_t>(next_hop_mtu, conn->mtu_ceiling);
 		conn->mtu_search_update();
 		// this is something of a speecial case, where we don't set mtu_last
 		// to the value in between the floor and the ceiling. We can update the
@@ -3333,7 +3333,7 @@ int utp_getpeername(utp_socket *conn, struct sockaddr *addr, socklen_t *addrlen)
 	return 0;
 }
 
-int utp_get_delays(UTPSocket *conn, uint32 *ours, uint32 *theirs, uint32 *age)
+int utp_get_delays(UTPSocket *conn, uint32_t *ours, uint32_t *theirs, uint32_t *age)
 {
 	assert(conn);
 	if (!conn) return -1;
@@ -3348,7 +3348,7 @@ int utp_get_delays(UTPSocket *conn, uint32 *ours, uint32 *theirs, uint32 *age)
 
 	if (ours)   *ours   = conn->our_hist.get_value();
 	if (theirs) *theirs = conn->their_hist.get_value();
-	if (age)    *age    = (uint32)(conn->ctx->current_ms - conn->last_measured_delay);
+	if (age)    *age    = (uint32_t)(conn->ctx->current_ms - conn->last_measured_delay);
 	return 0;
 }
 

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -155,7 +155,7 @@ enum {
 	ST_NUM_STATES,		// used for bounds checking
 };
 
-static const cstr flagnames[] = {
+static const char *const flagnames[] = {
 	"ST_DATA","ST_FIN","ST_STATE","ST_RESET","ST_SYN"
 };
 
@@ -170,7 +170,7 @@ enum CONN_STATE {
 	CS_DESTROY
 };
 
-static const cstr statenames[] = {
+static const char *const statenames[] = {
 	"UNINITIALIZED", "IDLE","SYN_SENT", "SYN_RECV", "CONNECTED","CONNECTED_FULL","DESTROY_DELAY","RESET","DESTROY"
 };
 

--- a/utp_internal.h
+++ b/utp_internal.h
@@ -60,9 +60,9 @@ enum bandwidth_type_t {
 
 struct PACKED_ATTRIBUTE RST_Info {
 	PackedSockAddr addr;
-	uint32 connid;
-	uint16 ack_nr;
-	uint64 timestamp;
+	uint32_t connid;
+	uint16_t ack_nr;
+	uint64_t timestamp;
 };
 
 // It's really important that we don't have duplicate keys in the hash table.
@@ -73,9 +73,9 @@ void UTP_FreeAll(struct UTPSocketHT *utp_sockets);
 
 struct UTPSocketKey {
 	PackedSockAddr addr;
-	uint32 recv_id;		 // "conn_seed", "conn_id"
+	uint32_t recv_id;		 // "conn_seed", "conn_id"
 
-	UTPSocketKey(const PackedSockAddr& _addr, uint32 _recv_id) {
+	UTPSocketKey(const PackedSockAddr& _addr, uint32_t _recv_id) {
 		memset(this, 0, sizeof(*this));
 		addr = _addr;
 		recv_id = _recv_id;
@@ -85,7 +85,7 @@ struct UTPSocketKey {
 		return recv_id == other.recv_id && addr == other.addr;
 	}
 
-	uint32 compute_hash() const {
+	uint32_t compute_hash() const {
 		return recv_id ^ addr.compute_hash();
 	}
 };
@@ -115,7 +115,7 @@ struct struct_utp_context {
 	void *userdata;
 	utp_callback_t* callbacks[UTP_ARRAY_SIZE];
 
-	uint64 current_ms;
+	uint64_t current_ms;
 	utp_context_stats context_stats;
 	UTPSocket *last_utp_socket;
 	Array<UTPSocket*> ack_sockets;
@@ -124,7 +124,7 @@ struct struct_utp_context {
 	size_t target_delay;
 	size_t opt_sndbuf;
 	size_t opt_rcvbuf;
-	uint64 last_check;
+	uint64_t last_check;
 
 	struct_utp_context();
 	~struct_utp_context();

--- a/utp_packedsockaddr.cpp
+++ b/utp_packedsockaddr.cpp
@@ -32,7 +32,7 @@
 
 #include "libutp_inet_ntop.h"
 
-byte PackedSockAddr::get_family() const
+uint8_t PackedSockAddr::get_family() const
 {
 	#if defined(__sh__)
 		return ((_sin6d[0] == 0) && (_sin6d[1] == 0) && (_sin6d[2] == htonl(0xffff)) != 0) ?
@@ -98,7 +98,7 @@ PackedSockAddr::PackedSockAddr(void)
 SOCKADDR_STORAGE PackedSockAddr::get_sockaddr_storage(socklen_t *len = NULL) const
 {
 	SOCKADDR_STORAGE sa;
-	const byte family = get_family();
+	const uint8_t family = get_family();
 	if (family == AF_INET) {
 		sockaddr_in *sin = (sockaddr_in*)&sa;
 		if (len) *len = sizeof(sockaddr_in);
@@ -121,7 +121,7 @@ SOCKADDR_STORAGE PackedSockAddr::get_sockaddr_storage(socklen_t *len = NULL) con
 cstr PackedSockAddr::fmt(str s, size_t len) const
 {
 	memset(s, 0, len);
-	const byte family = get_family();
+	const uint8_t family = get_family();
 	str i;
 	if (family == AF_INET) {
 		INET_NTOP(family, (uint32_t*)&_sin4, s, len);

--- a/utp_packedsockaddr.cpp
+++ b/utp_packedsockaddr.cpp
@@ -56,7 +56,7 @@ bool PackedSockAddr::operator!=(const PackedSockAddr& rhs) const
 	return !(*this == rhs);
 }
 
-uint32 PackedSockAddr::compute_hash() const {
+uint32_t PackedSockAddr::compute_hash() const {
 	return utp_hash_mem(&_in, sizeof(_in)) ^ _port;
 }
 
@@ -124,7 +124,7 @@ cstr PackedSockAddr::fmt(str s, size_t len) const
 	const byte family = get_family();
 	str i;
 	if (family == AF_INET) {
-		INET_NTOP(family, (uint32*)&_sin4, s, len);
+		INET_NTOP(family, (uint32_t*)&_sin4, s, len);
 		i = s;
 		while (*++i) {}
 	} else {

--- a/utp_packedsockaddr.cpp
+++ b/utp_packedsockaddr.cpp
@@ -118,11 +118,11 @@ SOCKADDR_STORAGE PackedSockAddr::get_sockaddr_storage(socklen_t *len = NULL) con
 }
 
 // #define addrfmt(x, s) x.fmt(s, sizeof(s))
-cstr PackedSockAddr::fmt(str s, size_t len) const
+cstr PackedSockAddr::fmt(char *s, size_t len) const
 {
 	memset(s, 0, len);
 	const uint8_t family = get_family();
-	str i;
+	char *i;
 	if (family == AF_INET) {
 		INET_NTOP(family, (uint32_t*)&_sin4, s, len);
 		i = s;

--- a/utp_packedsockaddr.cpp
+++ b/utp_packedsockaddr.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 
+#include <inttypes.h>
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
@@ -134,6 +135,6 @@ const char *PackedSockAddr::fmt(char *s, size_t len) const
 		while (*++i) {}
 		*i++ = ']';
 	}
-	snprintf(i, len - (i-s), ":%u", _port);
+	snprintf(i, len - (i-s), ":%" PRIu16, _port);
 	return s;
 }

--- a/utp_packedsockaddr.cpp
+++ b/utp_packedsockaddr.cpp
@@ -118,7 +118,7 @@ SOCKADDR_STORAGE PackedSockAddr::get_sockaddr_storage(socklen_t *len = NULL) con
 }
 
 // #define addrfmt(x, s) x.fmt(s, sizeof(s))
-cstr PackedSockAddr::fmt(char *s, size_t len) const
+const char *PackedSockAddr::fmt(char *s, size_t len) const
 {
 	memset(s, 0, len);
 	const uint8_t family = get_family();

--- a/utp_packedsockaddr.h
+++ b/utp_packedsockaddr.h
@@ -29,13 +29,13 @@ struct PACKED_ATTRIBUTE PackedSockAddr {
 	// The values are always stored here in network byte order
 	union {
 		byte _in6[16];		// IPv6
-		uint16 _in6w[8];	// IPv6, word based (for convenience)
-		uint32 _in6d[4];	// Dword access
+		uint16_t _in6w[8];	// IPv6, word based (for convenience)
+		uint32_t _in6d[4];	// Dword access
 		in6_addr _in6addr;	// For convenience
 	} _in;
 
 	// Host byte order
-	uint16 _port;
+	uint16_t _port;
 
 	#define _sin4 _in._in6d[3]	// IPv4 is stored where it goes if mapped
 
@@ -54,7 +54,7 @@ struct PACKED_ATTRIBUTE PackedSockAddr {
 	SOCKADDR_STORAGE get_sockaddr_storage(socklen_t *len) const;
 	cstr fmt(str s, size_t len) const;
 
-	uint32 compute_hash() const;
+	uint32_t compute_hash() const;
 } ALIGNED_ATTRIBUTE(4);
 
 #endif //__UTP_PACKEDSOCKADDR_H__

--- a/utp_packedsockaddr.h
+++ b/utp_packedsockaddr.h
@@ -28,7 +28,7 @@
 struct PACKED_ATTRIBUTE PackedSockAddr {
 	// The values are always stored here in network byte order
 	union {
-		byte _in6[16];		// IPv6
+		uint8_t _in6[16];		// IPv6
 		uint16_t _in6w[8];	// IPv6, word based (for convenience)
 		uint32_t _in6d[4];	// Dword access
 		in6_addr _in6addr;	// For convenience
@@ -43,7 +43,7 @@ struct PACKED_ATTRIBUTE PackedSockAddr {
 	#define _sin6w _in._in6w
 	#define _sin6d _in._in6d
 
-	byte get_family() const;
+	uint8_t get_family() const;
 	bool operator==(const PackedSockAddr& rhs) const;
 	bool operator!=(const PackedSockAddr& rhs) const;
 	void set(const SOCKADDR_STORAGE* sa, socklen_t len);

--- a/utp_packedsockaddr.h
+++ b/utp_packedsockaddr.h
@@ -52,7 +52,7 @@ struct PACKED_ATTRIBUTE PackedSockAddr {
 	PackedSockAddr(void);
 
 	SOCKADDR_STORAGE get_sockaddr_storage(socklen_t *len) const;
-	cstr fmt(char *s, size_t len) const;
+	const char *fmt(char *s, size_t len) const;
 
 	uint32_t compute_hash() const;
 } ALIGNED_ATTRIBUTE(4);

--- a/utp_packedsockaddr.h
+++ b/utp_packedsockaddr.h
@@ -52,7 +52,7 @@ struct PACKED_ATTRIBUTE PackedSockAddr {
 	PackedSockAddr(void);
 
 	SOCKADDR_STORAGE get_sockaddr_storage(socklen_t *len) const;
-	cstr fmt(str s, size_t len) const;
+	cstr fmt(char *s, size_t len) const;
 
 	uint32_t compute_hash() const;
 } ALIGNED_ATTRIBUTE(4);

--- a/utp_templates.h
+++ b/utp_templates.h
@@ -66,12 +66,12 @@ template <typename T> static inline T clamp(T v, T mi, T ma)
 
 namespace aux
 {
-	FORCEINLINE uint16 host_to_network(uint16 i) { return htons(i); }
-	FORCEINLINE uint32 host_to_network(uint32 i) { return htonl(i); }
-	FORCEINLINE int32 host_to_network(int32 i) { return htonl(i); }
-	FORCEINLINE uint16 network_to_host(uint16 i) { return ntohs(i); }
-	FORCEINLINE uint32 network_to_host(uint32 i) { return ntohl(i); }
-	FORCEINLINE int32 network_to_host(int32 i) { return ntohl(i); }
+	FORCEINLINE uint16_t host_to_network(uint16_t i) { return htons(i); }
+	FORCEINLINE uint32_t host_to_network(uint32_t i) { return htonl(i); }
+	FORCEINLINE int32_t host_to_network(int32_t i) { return htonl(i); }
+	FORCEINLINE uint16_t network_to_host(uint16_t i) { return ntohs(i); }
+	FORCEINLINE uint32_t network_to_host(uint32_t i) { return ntohl(i); }
+	FORCEINLINE int32_t network_to_host(int32_t i) { return ntohl(i); }
 }
 
 template <class T>
@@ -83,9 +83,9 @@ private:
 	T m_integer;
 };
 
-typedef big_endian<int32> int32_big;
-typedef big_endian<uint32> uint32_big;
-typedef big_endian<uint16> uint16_big;
+typedef big_endian<int32_t> int32_big;
+typedef big_endian<uint32_t> uint32_big;
+typedef big_endian<uint16_t> uint16_big;
 
 #if (defined(__SVR4) && defined(__sun))
 	#pragma pack(0)

--- a/utp_types.h
+++ b/utp_types.h
@@ -23,6 +23,8 @@
 #ifndef __UTP_TYPES_H__
 #define __UTP_TYPES_H__
 
+#include <stdint.h>
+
 // Allow libutp consumers or prerequisites to override PACKED_ATTRIBUTE
 #ifndef PACKED_ATTRIBUTE
 #if defined BROKEN_GCC_STRUCTURE_PACKING && defined __GNUC__
@@ -84,40 +86,14 @@
 
 // standard types
 typedef unsigned char byte;
-typedef unsigned char uint8;
-typedef signed char int8;
-typedef unsigned short uint16;
-typedef signed short int16;
 typedef unsigned int uint;
-typedef unsigned int uint32;
-typedef signed int int32;
-
-#ifdef _MSC_VER
-typedef unsigned __int64 uint64;
-typedef signed __int64 int64;
-#else
-typedef unsigned long long uint64;
-typedef long long int64;
-#endif
-
-/* compile-time assert */
-#ifndef CASSERT
-#define CASSERT( exp, name ) typedef int is_not_##name [ (exp ) ? 1 : -1 ];
-#endif
-
-CASSERT(8 == sizeof(uint64), sizeof_uint64_is_8)
-CASSERT(8 == sizeof(int64), sizeof_int64_is_8)
-
-#ifndef INT64_MAX
-#define INT64_MAX 0x7fffffffffffffffLL
-#endif
 
 // always ANSI
 typedef const char * cstr;
 typedef char * str;
 
 #ifndef __cplusplus
-typedef uint8 bool;
+typedef uint8_t bool;
 #endif
 
 #endif //__UTP_TYPES_H__

--- a/utp_types.h
+++ b/utp_types.h
@@ -79,7 +79,6 @@
 
 // always ANSI
 typedef const char * cstr;
-typedef char * str;
 
 #ifndef __cplusplus
 typedef uint8_t bool;

--- a/utp_types.h
+++ b/utp_types.h
@@ -77,9 +77,6 @@
 	typedef struct sockaddr_storage SOCKADDR_STORAGE;
 #endif
 
-// always ANSI
-typedef const char * cstr;
-
 #ifndef __cplusplus
 typedef uint8_t bool;
 #endif

--- a/utp_types.h
+++ b/utp_types.h
@@ -78,7 +78,6 @@
 #endif
 
 // standard types
-typedef unsigned char byte;
 typedef unsigned int uint;
 
 // always ANSI

--- a/utp_types.h
+++ b/utp_types.h
@@ -78,12 +78,6 @@
 	typedef struct sockaddr_storage SOCKADDR_STORAGE;
 #endif
 
-#ifdef WIN32
-	#define I64u "%I64u"
-#else
-	#define I64u "%Lu"
-#endif
-
 // standard types
 typedef unsigned char byte;
 typedef unsigned int uint;

--- a/utp_types.h
+++ b/utp_types.h
@@ -70,8 +70,7 @@
 #endif
 
 #ifdef _MSC_VER
-	#include <BaseTsd.h>
-	typedef SSIZE_T ssize_t;
+	typedef intptr_t ssize_t;
 #endif
 
 #ifdef POSIX

--- a/utp_types.h
+++ b/utp_types.h
@@ -23,6 +23,7 @@
 #ifndef __UTP_TYPES_H__
 #define __UTP_TYPES_H__
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // Allow libutp consumers or prerequisites to override PACKED_ATTRIBUTE
@@ -75,10 +76,6 @@
 
 #ifdef POSIX
 	typedef struct sockaddr_storage SOCKADDR_STORAGE;
-#endif
-
-#ifndef __cplusplus
-typedef uint8_t bool;
 #endif
 
 #endif //__UTP_TYPES_H__

--- a/utp_types.h
+++ b/utp_types.h
@@ -77,9 +77,6 @@
 	typedef struct sockaddr_storage SOCKADDR_STORAGE;
 #endif
 
-// standard types
-typedef unsigned int uint;
-
 // always ANSI
 typedef const char * cstr;
 typedef char * str;

--- a/utp_utils.h
+++ b/utp_utils.h
@@ -20,8 +20,8 @@
  * THE SOFTWARE.
  */
 
-uint64 utp_default_get_udp_mtu(utp_callback_arguments *args);
-uint64 utp_default_get_udp_overhead(utp_callback_arguments *args);
-uint64 utp_default_get_random(utp_callback_arguments *args);
-uint64 utp_default_get_milliseconds(utp_callback_arguments *args);
-uint64 utp_default_get_microseconds(utp_callback_arguments *args);
+uint64_t utp_default_get_udp_mtu(utp_callback_arguments *args);
+uint64_t utp_default_get_udp_overhead(utp_callback_arguments *args);
+uint64_t utp_default_get_random(utp_callback_arguments *args);
+uint64_t utp_default_get_milliseconds(utp_callback_arguments *args);
+uint64_t utp_default_get_microseconds(utp_callback_arguments *args);


### PR DESCRIPTION
This PR removes most of manually defined types in utp_types.h in favor of either standard integral types defined as part of C99, or built-in basic types, which reduces the chances of clashes with other code since the names were quite generic/common. All the changes here are done with dull find/replace, please do tell if there're any formatting issues or whatnot that you'd like me to fix.

Fixes: #122
Overlaps with: #70