### PR TITLE
Use _WIN32 instead of WIN32 to check for Windows

### DIFF
--- a/prop_sheets/debug-2012.props
+++ b/prop_sheets/debug-2012.props
@@ -11,7 +11,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>_DEBUG;WIN32;ENABLE_I18N;ENABLE_SRP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;ENABLE_I18N;ENABLE_SRP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>false</ExceptionHandling>
       <StringPooling>false</StringPooling>
       <EnableParallelCodeGeneration>false</EnableParallelCodeGeneration>

--- a/prop_sheets/release-2012.props
+++ b/prop_sheets/release-2012.props
@@ -27,7 +27,7 @@
       <CallingConvention>StdCall</CallingConvention>
       <CompileAs>Default</CompileAs>
       <CompileAsManaged>false</CompileAsManaged>
-      <PreprocessorDefinitions>NDEBUG;WIN32;ENABLE_I18N;ENABLE_SRP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;ENABLE_I18N;ENABLE_SRP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeaderOutputFile>c:\temp\$(ProjectName)-$(ConfigurationName)-$(PlatformName)-master.pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/utp_internal.h
+++ b/utp_internal.h
@@ -44,7 +44,7 @@ enum bandwidth_type_t {
 	header_overhead, retransmit_overhead
 };
 
-#ifdef WIN32
+#ifdef _WIN32
 	#ifdef _MSC_VER
 		#include "libutp_inet_ntop.h"
 	#endif

--- a/utp_types.h
+++ b/utp_types.h
@@ -42,7 +42,7 @@
 
 // hash.cpp needs socket definitions, which is why this networking specific
 // code is inclued in utypes.h
-#ifdef WIN32
+#ifdef _WIN32
 	#define _CRT_SECURE_NO_DEPRECATE
 	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
@@ -76,7 +76,7 @@
 	typedef struct sockaddr_storage SOCKADDR_STORAGE;
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 	#define I64u "%I64u"
 #else
 	#define I64u "%Lu"

--- a/utp_utils.cpp
+++ b/utp_utils.cpp
@@ -25,12 +25,12 @@
 #include "utp.h"
 #include "utp_types.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
-#else //!WIN32
+#else //!_WIN32
 	#include <time.h>
 	#include <sys/time.h>		// Linux needs both time.h and sys/time.h
 #endif
@@ -41,7 +41,7 @@
 
 #include "utp_utils.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 
 typedef ULONGLONG (WINAPI GetTickCount64Proc)(void);
 static GetTickCount64Proc *pt2GetTickCount64;
@@ -113,7 +113,7 @@ static inline uint64 UTP_GetMilliseconds()
 	return GetTickCount();
 }
 
-#else //!WIN32
+#else //!_WIN32
 
 static inline uint64 UTP_GetMicroseconds(void);
 static inline uint64 UTP_GetMilliseconds()
@@ -182,7 +182,7 @@ static uint64_t __GetMicroseconds()
 
 #endif //!__APPLE__
 
-#endif //!WIN32
+#endif //!_WIN32
 
 /*
  * Whew.  Okay.  After that #ifdef maze above, we now know we have a working


### PR DESCRIPTION
MinGW defines both _WIN32 and WIN32 (and may even be the only compiler doing so). Microsoft and Intel compilers only define _WIN32. Use the common one to eliminate the need in defining WIN32 explicitly.

Supersedes: #65