### PR TITLE
refactor: make utp_write() buf arg a const*

### DIFF
--- a/utp.h
+++ b/utp.h
@@ -142,7 +142,7 @@ typedef struct {
 
 // For utp_writev, to writes data from multiple buffers
 struct utp_iovec {
-	void *iov_base;
+	const void *iov_base;
 	size_t iov_len;
 };
 
@@ -166,7 +166,7 @@ void*			utp_get_userdata				(utp_socket *s);
 int				utp_setsockopt					(utp_socket *s, int opt, int val);
 int				utp_getsockopt					(utp_socket *s, int opt);
 int				utp_connect						(utp_socket *s, const struct sockaddr *to, socklen_t tolen);
-ssize_t			utp_write						(utp_socket *s, void *buf, size_t count);
+ssize_t			utp_write						(utp_socket *s, const void *buf, size_t count);
 ssize_t			utp_writev						(utp_socket *s, struct utp_iovec *iovec, size_t num_iovecs);
 int				utp_getpeername					(utp_socket *s, struct sockaddr *addr, socklen_t *addrlen);
 void			utp_read_drained				(utp_socket *s);

--- a/utp.h
+++ b/utp.h
@@ -167,7 +167,7 @@ int				utp_setsockopt					(utp_socket *s, int opt, int val);
 int				utp_getsockopt					(utp_socket *s, int opt);
 int				utp_connect						(utp_socket *s, const struct sockaddr *to, socklen_t tolen);
 ssize_t			utp_write						(utp_socket *s, const void *buf, size_t count);
-ssize_t			utp_writev						(utp_socket *s, struct utp_iovec *iovec, size_t num_iovecs);
+ssize_t			utp_writev						(utp_socket *s, const struct utp_iovec *iovec, size_t num_iovecs);
 int				utp_getpeername					(utp_socket *s, struct sockaddr *addr, socklen_t *addrlen);
 void			utp_read_drained				(utp_socket *s);
 int				utp_get_delays					(utp_socket *s, uint32 *ours, uint32 *theirs, uint32 *age);

--- a/utp_api.cpp
+++ b/utp_api.cpp
@@ -131,7 +131,7 @@ utp_context_stats* utp_get_context_stats(utp_context *ctx) {
 	return ctx ? &ctx->context_stats : NULL;
 }
 
-ssize_t utp_write(utp_socket *socket, void *buf, size_t len) {
+ssize_t utp_write(utp_socket *socket, const void *buf, size_t len) {
 	struct utp_iovec iovec = { buf, len };
 	return utp_writev(socket, &iovec, 1);
 }

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -3151,7 +3151,7 @@ int utp_process_icmp_error(utp_context *ctx, const byte *buffer, size_t len, con
 
 // Write bytes to the UTP socket.  Returns the number of bytes written.
 // 0 indicates the socket is no longer writable, -1 indicates an error
-ssize_t utp_writev(utp_socket *conn, struct utp_iovec *iovec_input, size_t num_iovecs)
+ssize_t utp_writev(utp_socket *conn, const struct utp_iovec *iovec_input, size_t num_iovecs)
 {
 	static utp_iovec iovec[UTP_IOV_MAX];
 


### PR DESCRIPTION
No functional changes; just a minor const-correctness change.

Use case: client code calls `utp_write()` or `utp_writev()` from a function that receives the data in `const` form, but currently has to cast away the const with `const_cast<void*>(data)` to match the current libutp API.