### PR TITLE
refactor: use std::min(), std::max()

### DIFF
--- a/utp_templates.h
+++ b/utp_templates.h
@@ -24,6 +24,7 @@
 #define __TEMPLATES_H__
 
 #include "utp_types.h"
+#include <algorithm>
 #include <assert.h>
 
 #if defined(POSIX)
@@ -42,14 +43,8 @@
 #endif
 
 // Utility templates
-#undef min
-#undef max
 
-template <typename T> static inline T min(T a, T b) { if (a < b) return a; return b; }
-template <typename T> static inline T max(T a, T b) { if (a > b) return a; return b; }
 
-template <typename T> static inline T min(T a, T b, T c) { return min(min(a,b),c); }
-template <typename T> static inline T max(T a, T b, T c) { return max(max(a,b),c); }
 template <typename T> static inline T clamp(T v, T mi, T ma)
 {
 	if (v > ma) v = ma;
@@ -125,7 +120,7 @@ public:
 		else { mem = (T*)realloc(mem, (alloc=a) * sizeof(T)); }
 	}
 
-	void Grow() { Resize(::max<size_t>(minsize, alloc * 2)); }
+	void Grow() { Resize(std::max<size_t>(minsize, alloc * 2)); }
 
 	inline size_t Append(const T &t) {
 		if (count >= alloc) Grow();


### PR DESCRIPTION
Dusting off an older PR. This is a followup to https://github.com/transmission/libutp/pull/7 and is described in that PR description.

Part two of a three-part series to use std:: tools instead of bespoke ones. Part three will fix #6.

- [x] Part 1: remove Array; use std::vector instead (#7)
- [x] Part 2: remove min, max; use std::min, std::max instead (this PR)
- [ ] Part 3: remove utpHashTable; use std::unordered_map instead

Unfortunately there don't seem to be any real tests for libutp, so the need to manually test is even greater than usual.